### PR TITLE
Add deduper feature to the bot

### DIFF
--- a/features/deduper.js
+++ b/features/deduper.js
@@ -1,0 +1,45 @@
+const deduper = {
+  monitoredChannels: [
+    "600025060379721760",
+    "600037597955489797",
+    "600037610005463050"
+  ],
+
+  // dupeExpireTime
+
+  lastMessageOfMember: {},
+
+  deleteMsgAndWarnUser: (msg, lastMsg) => {
+    msg.delete();
+    // prettier-ignore
+    msg.author
+        .send(`Hello there! It looks like you just posted a message to the #${msg.channel.name} channel on our server.
+			
+We don't allow cross posting, so I had to delete your message because it is idential as your last one posted on #${lastMsg.channel.name}. You can avoid this warning deleting the first message.
+
+Thank you :)
+
+:robot: This message was sent by a bot, please do not respond to it - in case of additional questions / issues, please contact one of our mods!`);
+  },
+
+  handleMessage: ({ msg, user }) => {
+    if (deduper.monitoredChannels.includes(msg.channel.id)) {
+      const userId = user.id;
+      const lastMessage = deduper.lastMessageOfMember[userId];
+      if (
+        lastMessage &&
+        !lastMessage.deleted &&
+        lastMessage.channel.id !== msg.channel.id &&
+        lastMessage.content === msg.content
+      ) {
+        deduper.deleteMsgAndWarnUser(msg, lastMessage);
+      } else {
+        deduper.lastMessageOfMember[userId] = msg;
+      }
+    }
+  }
+};
+
+module.exports = {
+  default: deduper
+};

--- a/features/deduper.js
+++ b/features/deduper.js
@@ -5,7 +5,7 @@ const deduper = {
     "600037610005463050"
   ],
 
-  // dupeExpireTime
+  dupeExpireTime: 2 * 60 * 1000, // 2 minutes to reject the duplicate as cross-post (ms)
 
   lastMessageOfMember: {},
 
@@ -15,7 +15,7 @@ const deduper = {
     msg.author
         .send(`Hello there! It looks like you just posted a message to the #${msg.channel.name} channel on our server.
 			
-We don't allow cross posting, so I had to delete your message because it is idential as your last one posted on #${lastMsg.channel.name}. You can avoid this warning deleting the first message.
+We don't allow cross-posting, so I had to delete your message because it is identical as your last one posted on #${lastMsg.channel.name}. You can avoid this warning deleting the first message or waiting 2 minutes.
 
 Thank you :)
 
@@ -26,11 +26,14 @@ Thank you :)
     if (deduper.monitoredChannels.includes(msg.channel.id)) {
       const userId = user.id;
       const lastMessage = deduper.lastMessageOfMember[userId];
+
       if (
         lastMessage &&
         !lastMessage.deleted &&
         lastMessage.channel.id !== msg.channel.id &&
-        lastMessage.content === msg.content
+        lastMessage.content === msg.content &&
+        msg.createdTimestamp - lastMessage.createdTimestamp <
+          deduper.dupeExpireTime
       ) {
         deduper.deleteMsgAndWarnUser(msg, lastMessage);
       } else {

--- a/features/deduper.js
+++ b/features/deduper.js
@@ -11,12 +11,12 @@ const deduper = {
   lastMessageOfMember: {},
 
   deleteMsgAndWarnUser: (msg, lastMsg) => {
-    msg.delete();
+    lastMsg.delete();
     // prettier-ignore
     msg.author
         .send(`Hello there! It looks like you just posted a message to the #${msg.channel.name} channel on our server.
 			
-We don't allow cross-posting, so I had to delete your message because it is identical as your last one posted on #${lastMsg.channel.name}. You can avoid this warning deleting the first message or waiting 2 minutes.
+We don't allow cross-posting, so I had to delete your previous message on #${lastMsg.channel.name} because it is identical as your recent message. You can avoid the deletion of messages waiting 2 minutes.
 
 Thank you :)
 

--- a/features/deduper.js
+++ b/features/deduper.js
@@ -1,4 +1,5 @@
 const deduper = {
+  logChannelId: "591326408396111907", // Channel where the bot will report about dedupes (#mod-log)
   dupeExpireTime: 2 * 60 * 1000, // 2 minutes to reject the duplicate as cross-post (ms)
   cleanerInterval: 10 * 60 * 1000, // Frees up the memory from 10 to 10 minutes (ms)
 
@@ -19,6 +20,7 @@ const deduper = {
 
   deleteMsgAndWarnUser: (msg, lastMsg) => {
     lastMsg.delete();
+
     // prettier-ignore
     msg.author
         .send(`Hello there! It looks like you just posted a message to the #${msg.channel.name} channel on our server.
@@ -28,6 +30,10 @@ We don't allow cross-posting, so I had to delete your previous message on #${las
 Thank you :)
 
 :robot: This message was sent by a bot, please do not respond to it - in case of additional questions / issues, please contact one of our mods!`);
+
+    msg.client.channels
+      .get(deduper.logChannelId)
+      .send(`Warned <@${msg.author.id}> for crossposting`);
   },
 
   handleMessage: ({ msg, user }) => {

--- a/features/deduper.js
+++ b/features/deduper.js
@@ -44,13 +44,18 @@ Thank you :)
     Object.keys(lastMessagesPerChannel).forEach(channelId => {
       const lastMessage = lastMessagesPerChannel[channelId];
 
+      // we take the difference between the time when this message was sent with the time when the last message was sent,
+      // if there is an interval bigger than `deduper.dupeExpireTime`, then it is not considered as a duplicate
+      const isWithinTheTimeLimit =
+        msg.createdTimestamp - lastMessage.createdTimestamp <
+        deduper.dupeExpireTime;
+
       if (
         lastMessage &&
         !lastMessage.deleted &&
         lastMessage.channel.id !== msg.channel.id &&
         lastMessage.content === msg.content &&
-        msg.createdTimestamp - lastMessage.createdTimestamp <
-          deduper.dupeExpireTime
+        isWithinTheTimeLimit
       ) {
         deduper.deleteMsgAndWarnUser(msg, lastMessage);
         shouldSaveMessageToList = false;
@@ -73,6 +78,8 @@ Thank you :)
         Object.keys(lastMessagesPerChannel).forEach(channelId => {
           const msg = lastMessagesPerChannel[channelId];
 
+          // if the message is older than the expire time it will never be considered a duplicate, so
+          // we can remove it from the array to free space
           if (Date.now() - msg.createdTimestamp > deduper.dupeExpireTime) {
             delete lastMessagesPerChannel[channelId];
           }

--- a/features/deduper.js
+++ b/features/deduper.js
@@ -28,7 +28,7 @@ const deduper = {
     // prettier-ignore
     msg.author
         .send(`Hello there! It looks like you just posted a message to the #${msg.channel.name} channel on our server.
-			
+
 We don't allow cross-posting, so I had to delete your previous message on #${lastMsg.channel.name} because it is identical as your recent message. You can avoid the deletion of messages waiting 2 minutes.
 
 Thank you :)

--- a/features/deduper.js
+++ b/features/deduper.js
@@ -1,10 +1,4 @@
 const deduper = {
-  monitoredChannels: [
-    "102860784329052160", // #general
-    "103696749012467712", // #need-help-0
-    "565213527673929729" // #need-help-1
-  ],
-
   dupeExpireTime: 2 * 60 * 1000, // 2 minutes to reject the duplicate as cross-post (ms)
   cleanerInterval: 10 * 60 * 1000, // Frees up the memory from 10 to 10 minutes (ms)
 

--- a/features/deduper.js
+++ b/features/deduper.js
@@ -1,8 +1,8 @@
 const deduper = {
   monitoredChannels: [
-    "600025060379721760",
-    "600037597955489797",
-    "600037610005463050"
+    "102860784329052160", // #general
+    "103696749012467712", // #need-help-0
+    "565213527673929729" // #need-help-1
   ],
 
   dupeExpireTime: 2 * 60 * 1000, // 2 minutes to reject the duplicate as cross-post (ms)

--- a/features/deduper.js
+++ b/features/deduper.js
@@ -6,6 +6,7 @@ const deduper = {
   ],
 
   dupeExpireTime: 2 * 60 * 1000, // 2 minutes to reject the duplicate as cross-post (ms)
+  cleanerInterval: 10 * 60 * 1000, // Frees up the memory from 10 to 10 minutes (ms)
 
   lastMessageOfMember: {},
 
@@ -40,6 +41,18 @@ Thank you :)
         deduper.lastMessageOfMember[userId] = msg;
       }
     }
+  },
+
+  registerCleaner: () => {
+    setInterval(() => {
+      Object.keys(deduper.lastMessageOfMember).forEach(userId => {
+        const msg = deduper.lastMessageOfMember[userId];
+
+        if (Date.now() - msg.createdTimestamp > deduper.dupeExpireTime) {
+          delete deduper.lastMessageOfMember[userId];
+        }
+      });
+    }, deduper.cleanerInterval);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const autoban = require("./features/autoban").default;
 const commands = require("./features/commands").default;
 const witInvite = require("./features/wit-invite").default;
 const stats = require("./features/stats").default;
+const deduper = require("./features/deduper").default;
 
 const bot = new discord.Client();
 bot.login(process.env.DISCORD_HASH);
@@ -94,6 +95,7 @@ channelHandlers.addHandler("479862475047567361", qna); // #general
 channelHandlers.addHandler("*", commands);
 // channelHandlers.addHandler('*', codeblock);
 channelHandlers.addHandler("*", autoban);
+channelHandlers.addHandler("*", deduper);
 
 bot.on("messageReactionAdd", (reaction, user) => {
   channelHandlers.handleReaction(reaction, user);

--- a/index.js
+++ b/index.js
@@ -82,6 +82,9 @@ logger.add(channelLog(bot, "479862475047567361"));
 // Amplitude metrics
 stats(bot);
 
+// start deduper cleaner
+deduper.registerCleaner();
+
 // reactiflux
 channelHandlers.addHandler("103882387330457600", jobs);
 channelHandlers.addHandler("541673256596537366", witInvite); // #women-in-tech


### PR DESCRIPTION
If a message is duplicated in one of the channels listed, the bot will delete the message and send a DM to the user. I need opinions on the time to forgive the cross-post (currently 2 minutes) and the DM message (that I literally copied from the `jobs` module hehe). Currently, the bot only reacts to the `#general`, `#need-help-0` and `#need-help-1` channels.

Closes #15 