### PR TITLE
feat(commands): add state updates may be async command

### DIFF
--- a/features/commands.js
+++ b/features/commands.js
@@ -87,7 +87,7 @@ https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html`,
     },
     {
       words: [`!stateupdates`, `!su`],
-      help: `Explains the issue with state updates being asynchronous`,
+      help: `Explains the implications involved with state updates being asynchronous`,
       handleMessage: msg => {
         msg.channel.send({
           embed: {

--- a/features/commands.js
+++ b/features/commands.js
@@ -102,22 +102,8 @@ const handleEvent = e => {
 }
 \`\`\`
 where \`state\` is not the most up to date value when you log it. This is caused by state updates being asynchronous, so synchronous logic after a state update should not rely on the state value.
-\`\`\`js
-// log it directly inside render
-console.log(state);
 
-// Or in a useEffect call
-useEffect(() => {
-  console.log(state);
-}, [state]);
-
-const handleEvent = e => {
-  setState(e.target.value);
-};
-\`\`\`
 Check out these resources for more information:
-https://github.com/facebook/react/issues/11527#issuecomment-360199710
-https://stackoverflow.com/questions/48563650/does-react-keep-the-order-for-state-updates/48610973#48610973
 https://gist.github.com/bpas247/e177a772b293025e5324219d231cf32c
 https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous for more information.`,
             color: 7506394

--- a/features/commands.js
+++ b/features/commands.js
@@ -115,7 +115,11 @@ const handleEvent = e => {
   setState(e.target.value);
 };
 \`\`\`
-Check out https://gist.github.com/bpas247/e177a772b293025e5324219d231cf32c and https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous for more information.`,
+Check out these resources for more information:
+https://github.com/facebook/react/issues/11527#issuecomment-360199710
+https://stackoverflow.com/questions/48563650/does-react-keep-the-order-for-state-updates/48610973#48610973
+https://gist.github.com/bpas247/e177a772b293025e5324219d231cf32c
+https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous for more information.`,
             color: 7506394
           }
         });

--- a/features/commands.js
+++ b/features/commands.js
@@ -86,7 +86,7 @@ https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html`,
       }
     },
     {
-      words: [`!stateUpdates`],
+      words: [`!stateupdates`, `!su`],
       help: `Explains the issue with state updates being asynchronous`,
       handleMessage: msg => {
         msg.channel.send({
@@ -101,11 +101,11 @@ const handleEvent = e => {
   console.log(state);
 }
 \`\`\`
-where \`state\` is not the most up to date value when you log it. This is caused by **state updates being asynchronous**, so synchronous logic after a state update should not rely on the state value.
+where \`state\` is not the most up to date value when you log it. This is caused by state updates being asynchronous.
 
 Check out these resources for more information:
 https://gist.github.com/bpas247/e177a772b293025e5324219d231cf32c
-https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous for more information.`,
+https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous`,
             color: 7506394
           }
         });

--- a/features/commands.js
+++ b/features/commands.js
@@ -94,7 +94,7 @@ https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html`,
             title:
               "State Updates May Be Asynchronous",
             type: "rich",
-            description: `Often times you might run into an issue like this
+            description: `Often times you run into an issue like this
 \`\`\`js
 const handleEvent = e => {
   setState(e.target.value);

--- a/features/commands.js
+++ b/features/commands.js
@@ -101,7 +101,7 @@ const handleEvent = e => {
   console.log(state);
 }
 \`\`\`
-where \`state\` is not the most up to date value when you log it. This is caused by state updates being asynchronous, so synchronous logic after a state update should not rely on the state value.
+where \`state\` is not the most up to date value when you log it. This is caused by **state updates being asynchronous**, so synchronous logic after a state update should not rely on the state value.
 
 Check out these resources for more information:
 https://gist.github.com/bpas247/e177a772b293025e5324219d231cf32c

--- a/features/commands.js
+++ b/features/commands.js
@@ -86,6 +86,42 @@ https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html`,
       }
     },
     {
+      words: [`!stateUpdates`],
+      help: `Explains the issue with state updates being asynchronous`,
+      handleMessage: msg => {
+        msg.channel.send({
+          embed: {
+            title:
+              "State Updates May Be Asynchronous",
+            type: "rich",
+            description: `Often times you might run into an issue like this
+\`\`\`js
+const handleEvent = e => {
+  setState(e.target.value);
+  console.log(state);
+}
+\`\`\`
+where \`state\` is not the most up to date value when you log it. This is caused by state updates being asynchronous, so synchronous logic after a state update should not rely on the state value.
+\`\`\`js
+// log it directly inside render
+console.log(state);
+
+// Or in a useEffect call
+useEffect(() => {
+  console.log(state);
+}, [state]);
+
+const handleEvent = e => {
+  setState(e.target.value);
+};
+\`\`\`
+Check out https://gist.github.com/bpas247/e177a772b293025e5324219d231cf32c and https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous for more information.`,
+            color: 7506394
+          }
+        });
+      }
+    },
+    {
       words: [`!bind`],
       help: `explains how and why to bind in React applications`,
       handleMessage: msg => {


### PR DESCRIPTION
Adds the "state updates may be async" command, for users who
get a *little* confused about the implications from it.

Fixes #24