### PR TITLE
Shorten the description of !ask

### DIFF
--- a/features/commands.js
+++ b/features/commands.js
@@ -178,19 +178,7 @@ https://reactjs.org/docs/lifting-state-up.html`,
           embed: {
             title: "Asking to ask",
             type: "rich",
-            description: `Instead of asking to ask, ask your question instead. People can help you better if they know your question.
-
-Example:
-
-Bad: "Hey can anyone help me with some JS?"
-Bad: "Anyone good with JS?"
-Good: "I'm having trouble adding a class to a div using JS. Can I have some help?"
-
-Please also provide any code that might help us using the following syntax:
-
-\\\`\\\`\\\`js
-// your code goes here
-\\\`\\\`\\\``,
+            description: `Instead of asking to ask, ask your question instead. People can help you better if they know your question.`,
             color: 7506394
           }
         });

--- a/features/commands.js
+++ b/features/commands.js
@@ -178,7 +178,17 @@ https://reactjs.org/docs/lifting-state-up.html`,
           embed: {
             title: "Asking to ask",
             type: "rich",
-            description: `Instead of asking to ask, ask your question instead. People can help you better if they know your question.`,
+            description: `Instead of asking to ask, ask your question instead. People can help you better if they know your question.
+
+Bad: "hey can anyone help me?"	
+Bad: "anyone good with redux?"
+Good: 
+> I'm trying to fire a redux action from my component, but it's not getting to the reducer.
+> \`\`\`js
+> // snippet of code
+> \`\`\`
+> I'm seeing an error, but I don't know if it's related.
+> \`Uncaught TypeError: undefined is not a function\``,
             color: 7506394
           }
         });


### PR DESCRIPTION
The example is too generic to be useful and doesn't have an actionable question, meanwhile the code help isn't as detailed as `!code` and is just taking up extra space