### PR TITLE
Allow commands to be DM'd to the bot

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -341,7 +341,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
 
 const commands: ChannelHandlers = {
   handleMessage: ({ msg }) => {
-    if (!msg.guild) {
+    if (!msg.guild && msg.channel.type !== "dm") {
       return;
     }
 

--- a/src/features/qna.ts
+++ b/src/features/qna.ts
@@ -1,4 +1,4 @@
-import { Message, TextChannel, DMChannel } from "discord.js";
+import { Message, TextChannel, DMChannel, NewsChannel } from "discord.js";
 import { ChannelHandlers } from "../types";
 
 const ALLOWED_ROLES = ["moderator", "Moderator", "admin", "Admin"];
@@ -24,7 +24,7 @@ const counterAsWord = (q: number) => {
   else return "more than three";
 };
 
-const flush = (channel: TextChannel | DMChannel) => {
+const flush = (channel: TextChannel | DMChannel | NewsChannel) => {
   prevMessagesIds.forEach(oldId =>
     channel.messages.fetch(oldId).then(msg => msg.delete())
   );


### PR DESCRIPTION
Looks like Discord's API changed or something or another and `msg.guild` is undefined for a DM, so this fixes that.

I tested with my local bot and it works.