### PR TITLE
Link to generic "Create Sandbox" page

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -216,7 +216,7 @@ Paste small bits of code directly in chat with syntax highlighting:
 \\\`\\\`\\\`
 
 Link a Gist to upload entire files: https://gist.github.com
-Link a Code Sandbox to share runnable examples: https://codesandbox.io/s/new
+Link a Code Sandbox to share runnable examples: https://codesandbox.io/s
 `,
           color: EMBED_COLOR
         }


### PR DESCRIPTION
The current Code Sandbox link goes directly to the JavaScript React template. This now goes to the template page so users have the option of using TypeScript, not using React, adding a backend, etc.