### PR TITLE
Improve commands list formatting and add new "TS" and "hooks" messages

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -276,7 +276,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
   },
   {
     words: [`!move`],
-    help: `allows you to move the conversation to another channel (usage: \`!move #toChannel @person1 @person2 @person3\`)`,
+    help: `allows you to move the conversation to another channel \n\t(usage: \`!move #toChannel @person1 @person2 @person3\`)`,
     category: "Reactiflux",
     handleMessage: msg => {
       const [, newChannel] = msg.content.split(" ");
@@ -482,6 +482,55 @@ To integrate it into your editor: https://prettier.io/docs/en/editors.html`,
 - Instead of "hey guys," try "hey folks", "hey all", or similar
 - Use "they/them/theirs" if you aren't sure of someone's pronouns
 - "thanks friend" instead of "thanks man"`,
+          color: EMBED_COLOR
+        }
+      });
+    }
+  },
+  {
+    words: [`!reactts`],
+    help: `Resources and tips for using React + TypeScript together`,
+    category: "React/Redux",
+    handleMessage: msg => {
+      msg.channel.send({
+        embed: {
+          title: "Resources for React + TypeScript",
+          type: "rich",
+          description: `The best resource for how to use TypeScript and React together is the React TypeScript CheatSheet. It has advice on how to type function components, hooks, event handlers, and much more:
+
+          https://react-typescript-cheatsheet.netlify.app/
+
+          Also, we advise against use the \`React.FC\` type for function components. Instead, declare the type of \`props\` directly, like:
+          \`function MyComp(props: MyCompProps) {}\`:
+          See this issue for details on why to avoid \`React.FC\`:
+
+          https://github.com/facebook/create-react-app/pull/8177
+          `,
+          color: EMBED_COLOR
+        }
+      });
+    }
+  },
+  {
+    words: [`!hooks`],
+    help: `Resources for learning React Hooks`,
+    category: "React/Redux",
+    handleMessage: msg => {
+      msg.channel.send({
+        embed: {
+          title: "Learning React Hooks",
+          type: "rich",
+          description: `React Hooks allow function components to have state, trigger side effects after rendering, and much more.
+
+          The official React docs are the best resource for learning hooks:
+          https://reactjs.org/docs/hooks-intro.html
+
+          However, the React docs still teach classes by default. A rewrite is in progress, but until then, there's a "React with Hooks" version of the React docs that uses hooks and function components for all examples:
+          https://reactwithhooks.netlify.app/
+
+          This article explains why hooks are important and what problems they solve:
+          https://ui.dev/why-react-hooks/
+          `,
           color: EMBED_COLOR
         }
       });

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -65,7 +65,7 @@ const commandsList: Command[] = [
         embed: {
           title: "The XY Issue",
           type: "rich",
-          description: `You may be experiencing an XY problem: http://xyproblem.info/ - basically, try to explain your end goal, instead of the error you got stuck on. Maybe there's a better way to approach the problem.`,
+          description: `You may be experiencing an XY problem: http://xyproblem.info/ .  Try to explain your end goal, instead of the error you got stuck on. Maybe there's a better way to approach the problem.`,
           color: EMBED_COLOR
         }
       });
@@ -90,7 +90,7 @@ https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367`,
   },
   {
     words: [`!derived`],
-    help: `links to the React docs regarding the getDerivedStateFromProps function (ab)use`,
+    help: `Links to the React docs advice to avoid copying props to state`,
     category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
@@ -98,7 +98,7 @@ https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367`,
           title:
             "You might not need getDerivedStateFrom props or state at all!",
           type: "rich",
-          description: `React 16.4 included a bugfix for getDerivedStateFromProps which caused some existing bugs in React components to reproduce more consistently. If this release exposed a case where your application was using an anti-pattern and didn’t work properly after the fix...
+          description: `Copying data from React props to component state is usually not necessary, and should generally be avoided. The React team offered advice on when "derived state" may actually be needed:
 
 https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html`,
           color: EMBED_COLOR
@@ -276,7 +276,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
   },
   {
     words: [`!move`],
-    help: `allows you to move the conversation to another channel, usage: !move #toChannel @person1 @person2 @person3 ...`,
+    help: `allows you to move the conversation to another channel (usage: \`!move #toChannel @person1 @person2 @person3\`)`,
     category: "Reactiflux",
     handleMessage: msg => {
       const [, newChannel] = msg.content.split(" ");

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -6,36 +6,45 @@ import { isStaff } from "../utils";
 
 const EMBED_COLOR = 7506394;
 
+type Categories = "Reactiflux" | "Communication" | "Web" | "React/Redux";
+
 type Command = {
   words: string[];
   help: string;
+  category: Categories;
   handleMessage: (msg: Message) => void;
 };
+
+const sortedCategories: Categories[] = [
+  "Reactiflux",
+  "Communication",
+  "Web",
+  "React/Redux"
+];
 
 const commandsList: Command[] = [
   {
     words: [`!commands`],
     help: `lists all available commands`,
+    category: "Reactiflux",
     handleMessage: msg => {
-      const payload = commandsList
-        .filter(trigger => trigger.help)
-        .map(trigger => {
-          return `${trigger.words.join(", ")} - ${trigger.help}`;
-        })
-        .join("\n")
-        .trim();
+      const commandsMessage = createCommandsMessage();
 
-      msg.channel.send(
-        `We have a few commands available: \`\`\`${payload}\`\`\``,
-        {
-          reply: msg.author
-        }
-      );
+      msg.channel.send({
+        embed: {
+          title: "Available Help Commands",
+          type: "rich",
+          description: commandsMessage,
+          color: EMBED_COLOR
+        },
+        reply: msg.author
+      });
     }
   },
   {
     words: [`!rrlinks`],
     help: `shares a repository of helpful links regarding React and Redux`,
+    category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -50,6 +59,7 @@ const commandsList: Command[] = [
   {
     words: [`!xy`],
     help: `explains the XY problem`,
+    category: "Communication",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -64,6 +74,7 @@ const commandsList: Command[] = [
   {
     words: [`!ymnnr`],
     help: `links to the You Might Not Need Redux article`,
+    category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -80,6 +91,7 @@ https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367`,
   {
     words: [`!derived`],
     help: `links to the React docs regarding the getDerivedStateFromProps function (ab)use`,
+    category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -95,8 +107,9 @@ https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html`,
     }
   },
   {
-    words: [`!stateupdates`, `!su`],
+    words: [`!su`, `!stateupdates`],
     help: `Explains the implications involved with state updates being asynchronous`,
+    category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -122,6 +135,7 @@ https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchron
   {
     words: [`!bind`],
     help: `explains how and why to bind in React applications`,
+    category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -164,6 +178,7 @@ Check out https://reactkungfu.com/2015/07/why-and-how-to-bind-methods-in-your-re
   {
     words: [`!lift`],
     help: `links to the React docs regarding the common need to "lift" state`,
+    category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -181,6 +196,7 @@ https://reactjs.org/docs/lifting-state-up.html`,
   {
     words: [`!ask`],
     help: `explains how to ask questions`,
+    category: "Reactiflux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -205,6 +221,7 @@ Good:
   {
     words: [`!code`, `!gist`],
     help: `explains how to attach code`,
+    category: "Reactiflux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -226,6 +243,7 @@ Link a TypeScript Playground to share types: https://www.typescriptlang.org/play
   {
     words: [`!ping`],
     help: `explains how to ping politely`,
+    category: "Reactiflux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -242,6 +260,7 @@ Similarly, don’t DM other members without asking first. All of the same proble
   {
     words: [`!inputs`],
     help: `provides links to uncontrolled vs controlled components`,
+    category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -258,6 +277,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
   {
     words: [`!move`],
     help: `allows you to move the conversation to another channel, usage: !move #toChannel @person1 @person2 @person3 ...`,
+    category: "Reactiflux",
     handleMessage: msg => {
       const [, newChannel] = msg.content.split(" ");
 
@@ -281,6 +301,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
   {
     words: [`!mdn`],
     help: `allows you to search something on MDN, usage: !mdn Array.prototype.map`,
+    category: "Web",
     handleMessage: async msg => {
       const [, ...args] = msg.content.split(" ");
       const query = args.join(" ");
@@ -323,6 +344,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
   {
     words: [`!appideas`],
     help: `provides a link to the best curated app ideas for beginners to advanced devs`,
+    category: "Web",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -340,6 +362,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
   {
     words: [`!cors`],
     help: `provides a link to what CORS is and how to fix it`,
+    category: "Web",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -358,8 +381,9 @@ Here's an article explaining the difference between the two: https://goshakkk.na
     }
   },
   {
-    words: [`!immutability`, `!imm`],
+    words: [`!imm`, `!immutability`],
     help: `provides resources for helping with immutability`,
+    category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -379,6 +403,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
   {
     words: [`!redux`],
     help: `Info and when and why to use Redux`,
+    category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -400,6 +425,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
   {
     words: [`!render`],
     help: `Explanation of how React rendering behavior works`,
+    category: "React/Redux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -424,6 +450,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
   {
     words: [`!formatting`, `!prettier`],
     help: `describes Prettier and explains how to use it to format code`,
+    category: "Reactiflux",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -444,6 +471,7 @@ To integrate it into your editor: https://prettier.io/docs/en/editors.html`,
   {
     words: [`!gender`],
     help: `reminds users to use gender-neutral language`,
+    category: "Communication",
     handleMessage: msg => {
       msg.channel.send({
         embed: {
@@ -462,6 +490,7 @@ To integrate it into your editor: https://prettier.io/docs/en/editors.html`,
   {
     words: ["@here", "@everyone"],
     help: "",
+    category: "Communication",
     handleMessage: msg => {
       if (!msg || !msg.guild) {
         return;
@@ -484,6 +513,44 @@ To integrate it into your editor: https://prettier.io/docs/en/editors.html`,
     }
   }
 ];
+
+const createCommandsMessage = () => {
+  const groupedMessages: { [key in Categories]: Command[] } = {
+    Reactiflux: [],
+    Communication: [],
+    Web: [],
+    "React/Redux": []
+  };
+
+  // Omit any commands that are internal, like the `@here` warning
+  const visibleCommands = commandsList.filter(command => !!command.help);
+
+  visibleCommands.forEach(command => {
+    groupedMessages[command.category].push(command);
+  });
+
+  const categoryDescriptions = sortedCategories.map(category => {
+    const commands = groupedMessages[category];
+    // Mutating in map(), but whatever
+    commands.sort((a, b) => {
+      // Assume there's at least one trigger word per command
+      return a.words[0].localeCompare(b.words[0]);
+    });
+
+    const boldTitle = `**${category}**`;
+    const commandDescriptions = commands
+      .map(command => {
+        const formattedWords = command.words.map(word => `**\`${word}\`**`);
+        return `${formattedWords.join(", ")}: ${command.help}`;
+      })
+      .join("\n");
+
+    const categoryDescription = `${boldTitle}\n${commandDescriptions}`;
+    return categoryDescription;
+  });
+
+  return categoryDescriptions.join("\n\n").trim();
+};
 
 const commands: ChannelHandlers = {
   handleMessage: ({ msg }) => {


### PR DESCRIPTION
This PR:

- Rewrites the generation of the "commands list" message so that:
  - Commands are grouped into categories ("Reactiflux", "Communication", "Web", and "React/Redux")
  - The message is a rich embed instead of monospace text
  - The commands themselves are formatted for emphasis
- Cleans up the wording of some existing messages
- Adds two new commands:
  - `!reactts`: Links to the React TypeScript Cheatsheet and warns against using `React.FC`
  - `!hooks`: Links to the official React hooks docs, the `reactwithhooks.netlify.app` docs port, and the "Why Hooks?" post
  
### Screenshots

Tested against Reactibutt.

New commands list:

![image](https://user-images.githubusercontent.com/1128784/102701931-6a098300-422a-11eb-91aa-6fc3305b2ffb.png)

React+TS message:

![image](https://user-images.githubusercontent.com/1128784/102701935-8ad1d880-422a-11eb-8869-8cc189acc5e9.png)

Hooks message:

![image](https://user-images.githubusercontent.com/1128784/102701943-9ae9b800-422a-11eb-82dd-9336c2e718b4.png)
