### PR TITLE
log bans to modlog channel

### DIFF
--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -1,6 +1,6 @@
-import { MessageReaction, Message, GuildMember, TextChannel } from "discord.js";
+import { MessageReaction, Message, GuildMember } from "discord.js";
 import cooldown from "./cooldown";
-import { isStaff, truncateMessage } from "../utils";
+import { getModLogChannel, isStaff, truncateMessage } from "../utils";
 import { ChannelHandlers } from "../types";
 
 const config = {
@@ -47,10 +47,7 @@ const reactionHandlers: ReactionHandlers = {
     const numberOfTotalReactions = usersWhoReacted.length;
     const numberOfStaffReactions = usersWhoReacted.filter(isStaff).length;
 
-    const modLogChannel = message.guild?.channels.cache.find(
-      channel =>
-        channel.name === "mod-log" || channel.id === "257930126145224704"
-    ) as TextChannel;
+    const modLogChannel = getModLogChannel(message.guild);
 
     const userNames = usersWhoReacted
       .filter(user => !isStaff(user))
@@ -138,10 +135,7 @@ Link: https://discord.com/channels/${message.guild?.id}/${message.channel.id}/${
 
     const numberOfTotalReactions = reactions.count;
 
-    const modLogChannel = message.guild.channels.cache.find(
-      channel =>
-        channel.name === "mod-log" || channel.id === "257930126145224704"
-    ) as TextChannel;
+    const modLogChannel = getModLogChannel(message.guild);
 
     let logMessage = "";
     const logMessageEnding = [

--- a/src/features/userModerationLogs.ts
+++ b/src/features/userModerationLogs.ts
@@ -1,13 +1,57 @@
-import { Guild, User } from "discord.js";
-import { getModLogChannel } from "../utils";
+import {
+  Guild,
+  GuildMember,
+  PartialGuildMember,
+  PartialUser,
+  User
+} from "discord.js";
+import { formatDate, getModLogChannel } from "../utils";
 
-export const handleBan = async (guild: Guild, user: User) => {
+export const handleBan = async (guild: Guild, user: User | PartialUser) => {
   const modLogChannel = getModLogChannel(guild);
-  const ban = await guild.fetchBan(user);
+  const auditLogs = await guild.fetchAuditLogs({
+    limit: 1,
+    type: "MEMBER_BAN_ADD"
+  });
+
+  const [ban] = auditLogs.entries.values();
+  const { executor, reason, createdAt } = ban;
+
+  const dateTimeString = formatDate(createdAt);
 
   modLogChannel.send(`
-    ${user} has been banned.
+    ${user} has been banned by ${executor} on ${dateTimeString}.
 
-Reason: \`\`\`${ban.reason}\`\`\`
+Reason: \`\`\`${reason || ""}\`\`\`
 `);
+};
+
+export const handleMemberRemove = async (
+  member: GuildMember | PartialGuildMember
+) => {
+  const { guild, user } = member;
+  const modLogChannel = getModLogChannel(guild);
+  const auditLogs = await guild.fetchAuditLogs({
+    limit: 1,
+    type: "MEMBER_KICK"
+  });
+
+  const [kick] = auditLogs.entries.values();
+  const { executor, reason, createdAt, target: kickTarget } = kick;
+  const dateTimeString = formatDate(createdAt);
+
+  // due to how this works the timeframe is to prevent a user to
+  // joining and leaving the server again and again after getting kicked
+  // and thus possibly spamming the modlog forever
+  const maxTimeout = 10000;
+  const withinTimeFrame =
+    new Date().getTime() - createdAt.getTime() < maxTimeout;
+
+  if (user && user.id === (kickTarget as User)?.id && withinTimeFrame) {
+    modLogChannel.send(`
+    ${member} has been kicked by ${executor} on ${dateTimeString}.
+
+Reason: \`\`\`${reason || ""}\`\`\`
+    `);
+  }
 };

--- a/src/features/userModerationLogs.ts
+++ b/src/features/userModerationLogs.ts
@@ -1,0 +1,13 @@
+import { Guild, User } from "discord.js";
+import { getModLogChannel } from "../utils";
+
+export const handleBan = async (guild: Guild, user: User) => {
+  const modLogChannel = getModLogChannel(guild);
+  const ban = await guild.fetchBan(user);
+
+  modLogChannel.send(`
+    ${user} has been banned.
+
+Reason: \`\`\`${ban.reason}\`\`\`
+`);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import commands from "./features/commands";
 import setupStats from "./features/stats";
 import emojiMod from "./features/emojiMod";
 import { ChannelHandlers } from "./types";
+import { handleBan } from "./features/userModerationLogs";
 
 const bot = new discord.Client({
   partials: ["MESSAGE", "CHANNEL", "REACTION"]
@@ -136,6 +137,8 @@ bot.on("error", err => {
     logger.log("ERR", err + "");
   }
 });
+
+bot.on("guildBanAdd", handleBan);
 
 const errorHandler = (error: any) => {
   if (error && error.message) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import commands from "./features/commands";
 import setupStats from "./features/stats";
 import emojiMod from "./features/emojiMod";
 import { ChannelHandlers } from "./types";
-import { handleBan } from "./features/userModerationLogs";
+import { handleBan, handleMemberRemove } from "./features/userModerationLogs";
 
 const bot = new discord.Client({
   partials: ["MESSAGE", "CHANNEL", "REACTION"]
@@ -139,6 +139,7 @@ bot.on("error", err => {
 });
 
 bot.on("guildBanAdd", handleBan);
+bot.on("guildMemberRemove", handleMemberRemove);
 
 const errorHandler = (error: any) => {
   if (error && error.message) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,3 +27,14 @@ export const getModLogChannel = (guild: Guild) => {
     channel => channel.name === "mod-log" || channel.id === "257930126145224704"
   ) as TextChannel;
 };
+
+export const formatDate = (date: Date) =>
+  date.toLocaleString("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true
+  });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { GuildMember } from "discord.js";
+import { Guild, GuildMember, TextChannel } from "discord.js";
 
 const staffRoles = ["mvp", "moderator", "admin", "admins"];
 
@@ -20,4 +20,10 @@ export const truncateMessage = (
   if (message.length > maxLength) return `${message.slice(0, maxLength)}...`;
 
   return message;
+};
+
+export const getModLogChannel = (guild: Guild) => {
+  return guild.channels.cache.find(
+    channel => channel.name === "mod-log" || channel.id === "257930126145224704"
+  ) as TextChannel;
 };


### PR DESCRIPTION
this is a PR to fix #45 partially. 

Unfortunately it's not possible to get the info of who banned the user. 

It doesn't seem to be possible to log kicks specifically. There is a [guildMemberRemove ](https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildMemberRemove) event but that seems to trigger everytime a user leaves or gets kicked. You can't distinguish the two. 

I tried to use the `deleted` property on the GuildMember object that gets passed in the guildMemberRemove event but it seems to be false every time.