### PR TITLE
add CSB github repo linking to !code command

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -234,6 +234,7 @@ Good:
 
 Link a Gist to upload entire files: https://gist.github.com
 Link a Code Sandbox to share runnable examples: https://codesandbox.io/s
+Link a Code Sandbox to an existing GitHub repo: https://codesandbox.io/s/github/<username>/<reponame>
 Link a TypeScript Playground to share types: https://www.typescriptlang.org/play
 `,
           color: EMBED_COLOR


### PR DESCRIPTION
If a user already has a GitHub repo published, they can use CodeSandbox's GitHub integration to directly import their project into CSB, without having to copy/paste their code into a new CSB. This patch adds a small blurb to the `!code` command to demonstrate the usage.