### PR TITLE
Switch !mdn to use mdn_url response field instead of slugs

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -322,7 +322,12 @@ Here's an article explaining the difference between the two: https://goshakkk.na
         return;
       }
 
-      const { title, excerpt: description, slug, locale } = topResult;
+      const {
+        title,
+        excerpt: description,
+        mdn_url: mdnUrl,
+        locale
+      } = topResult;
 
       await msg.channel.send({
         embed: {
@@ -336,7 +341,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
           title,
           description,
           color: 0x83d0f2,
-          url: `https://developer.mozilla.org/${locale}/${slug}`
+          url: `https://developer.mozilla.org${mdnUrl}`
         }
       });
 


### PR DESCRIPTION
Looks like MDN's search API behavior changed, so using the slug field to build an MDN article path is no longer sufficient (slugs are missing /docs prefix). As a fix, use the mdn_url field from the search API response instead, which seems more like what we need.