### PR TITLE
Remove DM after warning

### DIFF
--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -98,19 +98,6 @@ const reactionHandlers: ReactionHandlers = {
         });
       }
     }
-
-    const privateMessageToSender = `You've received a warning from the moderators on your message in ${
-      message.channel
-    }
-
-Your message:
-\`${truncateMessage(message.content)}\`
-
-Link: https://discord.com/channels/${message.guild?.id}/${message.channel.id}/${
-      message.id
-    }`;
-
-    message.author.send(privateMessageToSender);
   },
   "👎": (reaction, message, member) => {
     if (!message.guild || cooldown.hasCooldown(member.id, "thumbsdown")) {


### PR DESCRIPTION
This does more harm than good until we can get an actual "log-in-#mod-log-but-not-DM-user" reaction.