### PR TITLE
Feature/#95: Prevent channels being misused for bot testing

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -2,7 +2,11 @@ import fetch from "node-fetch";
 import { Message, TextChannel } from "discord.js";
 import cooldown from "./cooldown";
 import { ChannelHandlers } from "../types";
-import { isStaff } from "../utils";
+import {
+  isStaff,
+  isBotDisabledInChannel,
+  notifyUserBotResponseWasPrevented
+} from "../utils";
 
 const EMBED_COLOR = 7506394;
 
@@ -622,6 +626,17 @@ const commands: ChannelHandlers = {
 
       if (keyword) {
         if (cooldown.hasCooldown(msg.author.id, `commands.${keyword}`)) return;
+
+        const { name: channelName } = msg.channel as TextChannel;
+
+        const hasPreventedBotResponse = isBotDisabledInChannel(channelName);
+
+        if (hasPreventedBotResponse) {
+          notifyUserBotResponseWasPrevented(msg, channelName);
+
+          return;
+        }
+
         cooldown.addCooldown(msg.author.id, `commands.${keyword}`);
         command.handleMessage(msg);
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { GuildMember } from "discord.js";
+import { GuildMember, Message } from "discord.js";
 
 const staffRoles = ["mvp", "moderator", "admin", "admins"];
 
@@ -20,4 +20,27 @@ export const truncateMessage = (
   if (message.length > maxLength) return `${message.slice(0, maxLength)}...`;
 
   return message;
+};
+
+const disabledBotChannelNames = ["random"];
+
+export const isBotDisabledInChannel = (channelName: string) => {
+  return disabledBotChannelNames.includes(channelName);
+};
+
+export const notifyUserBotResponseWasPrevented = async (
+  message: Message,
+  channelName: string
+) => {
+  const { author, channel } = message;
+
+  try {
+    await author.send(
+      `Please do not test bot commands in the #${channelName} channel. You can test them here.`
+    );
+  } catch {
+    await channel.send(
+      `Please do not test bot commands in the #${channelName} channel. You can direct message me to test them (you may need to enable direct messages from users in this server).`
+    );
+  }
 };


### PR DESCRIPTION
PR for #95 

This pull request helps to prevent channels from being misused for bot testing.

### Changes

- Add a list of channels in which the bot is disabled.
- Send a direct message to the user prompting them to test bot commands in direct messages.
  - If the user has direct messages from other users disabled on the server, notify them via the channel they triggered the bot command in.
  
### Notes
  
 - This is my first time ever looking at a Discord bot so please review with extra caution.
 - I had to cast the channel object to a `TextChannel` to access the `name` property. I don't like this, but this appears to be standard from what I could find on some Discord.js issues. 
  
