### PR TITLE
Prevent non-staff from reacting with ⚠️ and send a clarifying DM

### DIFF
--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -30,14 +30,22 @@ type ReactionHandlers = {
 
 const reactionHandlers: ReactionHandlers = {
   "⚠️": (reaction, message, member) => {
-    // Skip if the user that reacted isn't in the staff or the post is from someone
-    // from the staff
+    // Skip if the post is from someone from the staff
     if (
       !message.guild ||
       !message.author ||
-      !isStaff(member) ||
       isStaff(message.guild.member(message.author.id))
     ) {
+      return;
+    }
+    // If the user that reacted isn't in the staff, remove the reaction, send a
+    if (!isStaff(member)) {
+      reaction.users.remove(member.id);
+      member.send([
+        "Hey there! 👋",
+        "The ⚠️ reaction is reserved for staff usage as part of our moderation system.  If you would like to mark a message as needing moderator attention, you can use react with 👎 instead.",
+        "Thanks!",
+      ]);
       return;
     }
 


### PR DESCRIPTION
We silently ignore ⚠️ reactions if they aren't from staff, which can make it hard for the user to tell if they've done anything or not.  This changes the logic to remove the ⚠️ reaction and DM the user explaining why it was removed.

(We talked about counting ⚠️ reactions from staff as if they were 👎, but is simpler to implement and I think ultimately clearer in result)