### PR TITLE
Fix modlog 👎 triggers

### DIFF
--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -34,7 +34,9 @@ const handleReport = (
   reportedMessage: Message,
   logBody: string,
 ) => {
-  const simplifiedContent = simplifyString(reportedMessage.content);
+  const simplifiedContent = `${reportedMessage.author.id}${simplifyString(
+    reportedMessage.content,
+  )}`;
   const cached = warningMessages.get(simplifiedContent);
 
   // Schedule cleanup for logged messages


### PR DESCRIPTION
These were incorrectly triggering "dedupe" logic, which meant multiple thumbs downs would trigger separate warnings (pinging mods each time). I removed the cleanup, which is equivalent to what we had before. This means it slowly leaks memory, but it grows with each logged warning so that's not going to be a major problem.

I also added user ID to the hashed message used to dedupe warnings, so if multiple users send the same message it won't count them as duplicates.