### PR TITLE
Small refactors

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -1,4 +1,4 @@
-export const sleep = (duration: number) =>
+export const sleep = (seconds: number) =>
   new Promise<void>((resolve) => {
-    setTimeout(() => resolve(), duration * 1000);
+    setTimeout(() => resolve(), seconds * 1000);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,10 @@ addHandler("*", tsPlaygroundLinkShortener);
 
 bot.on("messageReactionAdd", handleReaction);
 
+bot.on("threadCreate", (thread) => {
+  thread.join();
+});
+
 bot.on("messageCreate", async (msg) => {
   if (msg.author?.id === bot.user?.id) return;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,19 +79,23 @@ const channelHandlersById: ChannelHandlersById = {};
 
 const addHandler = (
   oneOrMoreChannels: string | string[],
-  channelHandlers: ChannelHandlers,
+  oneOrMoreHandlers: ChannelHandlers | ChannelHandlers[],
 ) => {
   const channels =
     typeof oneOrMoreChannels === "string"
       ? [oneOrMoreChannels]
       : oneOrMoreChannels;
+  const handlers =
+    oneOrMoreHandlers instanceof Array
+      ? oneOrMoreHandlers
+      : [oneOrMoreHandlers];
 
   channels.forEach((channelId) => {
-    const handlers = channelHandlersById[channelId];
-    if (handlers) {
-      handlers.push(channelHandlers);
+    const existingHandlers = channelHandlersById[channelId];
+    if (existingHandlers) {
+      existingHandlers.concat(handlers);
     } else {
-      channelHandlersById[channelId] = [channelHandlers];
+      channelHandlersById[channelId] = handlers;
     }
   });
 };
@@ -144,12 +148,13 @@ setupStats(bot);
 addHandler("103882387330457600", jobs);
 
 // common
-addHandler("*", commands);
-// addHandler('*', codeblock);
-addHandler("*", autoban);
-addHandler("*", emojiMod);
-addHandler("*", autodelete);
-addHandler("*", tsPlaygroundLinkShortener);
+addHandler("*", [
+  commands,
+  autoban,
+  emojiMod,
+  autodelete,
+  tsPlaygroundLinkShortener,
+]);
 
 bot.on("messageReactionAdd", handleReaction);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ const addHandler = (
   channels.forEach((channelId) => {
     const existingHandlers = channelHandlersById[channelId];
     if (existingHandlers) {
-      existingHandlers.concat(handlers);
+      existingHandlers.push(...handlers);
     } else {
       channelHandlersById[channelId] = handlers;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,11 +77,23 @@ export type ChannelHandlersById = {
 
 const channelHandlersById: ChannelHandlersById = {};
 
-const addHandler = (channelId: string, channelHandlers: ChannelHandlers) => {
-  channelHandlersById[channelId] = [
-    ...(channelHandlersById[channelId] || []),
-    channelHandlers,
-  ];
+const addHandler = (
+  oneOrMoreChannels: string | string[],
+  channelHandlers: ChannelHandlers,
+) => {
+  const channels =
+    typeof oneOrMoreChannels === "string"
+      ? [oneOrMoreChannels]
+      : oneOrMoreChannels;
+
+  channels.forEach((channelId) => {
+    const handlers = channelHandlersById[channelId];
+    if (handlers) {
+      handlers.push(channelHandlers);
+    } else {
+      channelHandlersById[channelId] = [channelHandlers];
+    }
+  });
 };
 
 const handleMessage = async (message: Message) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import autodelete from "./features/autodelete-spam";
 import { ChannelHandlers } from "./types";
 import { scheduleMessages } from "./features/scheduled-messages";
 import tsPlaygroundLinkShortener from "./features/tsplay";
+import { CHANNELS } from "./constants";
 
 export const bot = new discord.Client({
   intents: [
@@ -145,7 +146,7 @@ if (process.env.BOT_LOG) {
 setupStats(bot);
 
 // reactiflux
-addHandler("103882387330457600", jobs);
+addHandler(CHANNELS.jobBoard, jobs);
 
 // common
 addHandler("*", [


### PR DESCRIPTION
* Allow arrays of channel IDs/handlers in `addHandler`
* Rename `duration` -> `seconds` in `sleep()`, for clearer intelligence
* Use `CHANNELS.jobBoard` instead of string id

(This is a stacked diff off #145)