### PR TITLE
Add support for thread-only channels

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const staffRoles = ["mvp", "moderator", "admin", "admins"];
 
 export const enum CHANNELS {
   "helpReact" = "103696749012467712",
+  "helpThreadsReact" = "565213527673929729",
   "helpJs" = "565213527673929729",
   "random" = "103325358643752960",
   "jobBoard" = "103882387330457600",

--- a/src/features/autothread.ts
+++ b/src/features/autothread.ts
@@ -1,0 +1,30 @@
+import { format } from "date-fns";
+import { sleep } from "../helpers/misc";
+import { ChannelHandlers } from "../types";
+
+const autoThread: ChannelHandlers = {
+  handleMessage: async ({ msg: maybeMessage }) => {
+    const msg = maybeMessage.partial
+      ? await maybeMessage.fetch()
+      : maybeMessage;
+
+    if (msg.type === "REPLY") {
+      const repliedTo = await msg.fetchReference();
+      // Allow members to reply to their own messages, as "followup" threads
+      // If they replied to someone else, delete it and let them know why
+      if (msg.author.id !== repliedTo.author.id) {
+        msg.author.send(msg.content);
+        const reply = await msg.reply(
+          "This is a thread-only channel! Please reply in that message’s thread. Your message has been DM'd to you.",
+        );
+        msg.delete();
+        sleep(5).then(() => reply.delete());
+        return;
+      }
+    }
+    msg.startThread({
+      name: `${msg.author.username} – ${format(new Date(), "HH-mm MMM d")}`,
+    });
+  },
+};
+export default autoThread;

--- a/src/features/autothread.ts
+++ b/src/features/autothread.ts
@@ -1,6 +1,43 @@
 import { format } from "date-fns";
+import { Message, PartialMessage } from "discord.js";
+import { constructDiscordLink } from "../helpers/discord";
 import { sleep } from "../helpers/misc";
 import { ChannelHandlers } from "../types";
+
+const CHECKS = ["☑️", "✔️", "✅"];
+
+const lockWithReply = ({
+  content: msg,
+  message,
+  starter,
+  shouldReply,
+}: {
+  content: string;
+  message: Message | PartialMessage;
+  starter: Message | PartialMessage;
+  shouldReply: boolean;
+}) => {
+  const { channel: thread } = message;
+  if (!thread.isThread()) {
+    return;
+  }
+
+  const content = `${msg}
+
+If you have a a followup question, you may reply to this thread so other members know they're related. ${constructDiscordLink(
+    starter,
+  )}
+
+Threads are closed automatically after 6 hours, or if the member who started it reacts to a message with ✅ to mark that as the accepted answer.`;
+
+  (shouldReply
+    ? message.reply({ content, allowedMentions: { repliedUser: false } })
+    : thread.send(content)
+  ).then(() => {
+    thread.setLocked(true);
+    thread.setArchived(true);
+  });
+};
 
 const autoThread: ChannelHandlers = {
   handleMessage: async ({ msg: maybeMessage }) => {
@@ -15,7 +52,7 @@ const autoThread: ChannelHandlers = {
       if (msg.author.id !== repliedTo.author.id) {
         msg.author.send(msg.content);
         const reply = await msg.reply(
-          "This is a thread-only channel! Please reply in that message’s thread. Your message has been DM'd to you.",
+          "This is a thread-only channel! Please reply in that message’s thread. Your message has been DM’d to you.",
         );
         msg.delete();
         sleep(5).then(() => reply.delete());
@@ -25,6 +62,26 @@ const autoThread: ChannelHandlers = {
     msg.startThread({
       name: `${msg.author.username} – ${format(new Date(), "HH-mm MMM d")}`,
     });
+  },
+  handleReaction: async ({ reaction }) => {
+    if (!CHECKS.includes(reaction.emoji.toString())) {
+      return;
+    }
+
+    const { channel: thread } = reaction.message;
+    const starter = thread.isThread()
+      ? await thread.fetchStarterMessage()
+      : undefined;
+
+    // If the reaction was sent by the original thread author, lock the thread
+    if (starter && reaction.users.cache.has(starter.author.id)) {
+      lockWithReply({
+        content: `This question has an answer! Thank you for helping 😄`,
+        message: reaction.message,
+        starter,
+        shouldReply: true,
+      });
+    }
   },
 };
 export default autoThread;

--- a/src/helpers/discord.ts
+++ b/src/helpers/discord.ts
@@ -1,4 +1,4 @@
-import { Message, GuildMember } from "discord.js";
+import { Message, GuildMember, PartialMessage } from "discord.js";
 import { staffRoles } from "../constants";
 
 export const isStaff = (member: GuildMember | null | undefined) => {
@@ -9,5 +9,5 @@ export const isStaff = (member: GuildMember | null | undefined) => {
   );
 };
 
-export const constructDiscordLink = (message: Message) =>
+export const constructDiscordLink = (message: Message | PartialMessage) =>
   `https://discord.com/channels/${message.guild?.id}/${message.channel.id}/${message.id}`;

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -1,4 +1,4 @@
-export const sleep = (duration: number) =>
+export const sleep = (seconds: number) =>
   new Promise<void>((resolve) => {
-    setTimeout(() => resolve(), duration * 1000);
+    setTimeout(() => resolve(), seconds * 1000);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,10 @@ addHandler("*", tsPlaygroundLinkShortener);
 
 bot.on("messageReactionAdd", handleReaction);
 
+bot.on("threadCreate", (thread) => {
+  thread.join();
+});
+
 bot.on("messageCreate", async (msg) => {
   if (msg.author?.id === bot.user?.id) return;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,19 +79,23 @@ const channelHandlersById: ChannelHandlersById = {};
 
 const addHandler = (
   oneOrMoreChannels: string | string[],
-  channelHandlers: ChannelHandlers,
+  oneOrMoreHandlers: ChannelHandlers | ChannelHandlers[],
 ) => {
   const channels =
     typeof oneOrMoreChannels === "string"
       ? [oneOrMoreChannels]
       : oneOrMoreChannels;
+  const handlers =
+    oneOrMoreHandlers instanceof Array
+      ? oneOrMoreHandlers
+      : [oneOrMoreHandlers];
 
   channels.forEach((channelId) => {
-    const handlers = channelHandlersById[channelId];
-    if (handlers) {
-      handlers.push(channelHandlers);
+    const existingHandlers = channelHandlersById[channelId];
+    if (existingHandlers) {
+      existingHandlers.concat(handlers);
     } else {
-      channelHandlersById[channelId] = [channelHandlers];
+      channelHandlersById[channelId] = handlers;
     }
   });
 };
@@ -144,12 +148,13 @@ setupStats(bot);
 addHandler("103882387330457600", jobs);
 
 // common
-addHandler("*", commands);
-// addHandler('*', codeblock);
-addHandler("*", autoban);
-addHandler("*", emojiMod);
-addHandler("*", autodelete);
-addHandler("*", tsPlaygroundLinkShortener);
+addHandler("*", [
+  commands,
+  autoban,
+  emojiMod,
+  autodelete,
+  tsPlaygroundLinkShortener,
+]);
 
 bot.on("messageReactionAdd", handleReaction);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,11 @@ const handleReaction = (
   reaction: MessageReaction | PartialMessageReaction,
   user: User | PartialUser,
 ) => {
-  const channelId = reaction.message.channel.id;
+  // if reaction is in a thread, use the parent channel ID
+  const { channel } = reaction.message;
+  const channelId = channel.isThread()
+    ? channel.parentId || channel.id
+    : channel.id;
   const handlers = channelHandlersById[channelId];
 
   if (handlers) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,13 @@ import commands from "./features/commands";
 import setupStats from "./features/stats";
 import emojiMod from "./features/emojiMod";
 import autodelete from "./features/autodelete-spam";
-import autothread from "./features/autothread";
+import autothread, { cleanupThreads } from "./features/autothread";
 
 import { ChannelHandlers } from "./types";
 import { scheduleMessages } from "./features/scheduled-messages";
 import tsPlaygroundLinkShortener from "./features/tsplay";
 import { CHANNELS } from "./constants";
+import { scheduleTask } from "./helpers/schedule";
 
 export const bot = new discord.Client({
   intents: [
@@ -163,7 +164,14 @@ addHandler("*", [
   tsPlaygroundLinkShortener,
 ]);
 
-addHandler([CHANNELS.helpJs, CHANNELS.helpThreadsReact], autothread);
+const threadChannels = [CHANNELS.helpJs, CHANNELS.helpThreadsReact];
+
+addHandler(threadChannels, autothread);
+bot.on("ready", () => {
+  scheduleTask(1000 * 60 * 30, () => {
+    cleanupThreads(threadChannels, bot);
+  });
+});
 
 bot.on("messageReactionAdd", handleReaction);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ import commands from "./features/commands";
 import setupStats from "./features/stats";
 import emojiMod from "./features/emojiMod";
 import autodelete from "./features/autodelete-spam";
+import autothread from "./features/autothread";
+
 import { ChannelHandlers } from "./types";
 import { scheduleMessages } from "./features/scheduled-messages";
 import tsPlaygroundLinkShortener from "./features/tsplay";
@@ -156,6 +158,8 @@ addHandler("*", [
   autodelete,
   tsPlaygroundLinkShortener,
 ]);
+
+addHandler([CHANNELS.helpJs, CHANNELS.helpThreadsReact], autothread);
 
 bot.on("messageReactionAdd", handleReaction);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,11 +77,23 @@ export type ChannelHandlersById = {
 
 const channelHandlersById: ChannelHandlersById = {};
 
-const addHandler = (channelId: string, channelHandlers: ChannelHandlers) => {
-  channelHandlersById[channelId] = [
-    ...(channelHandlersById[channelId] || []),
-    channelHandlers,
-  ];
+const addHandler = (
+  oneOrMoreChannels: string | string[],
+  channelHandlers: ChannelHandlers,
+) => {
+  const channels =
+    typeof oneOrMoreChannels === "string"
+      ? [oneOrMoreChannels]
+      : oneOrMoreChannels;
+
+  channels.forEach((channelId) => {
+    const handlers = channelHandlersById[channelId];
+    if (handlers) {
+      handlers.push(channelHandlers);
+    } else {
+      channelHandlersById[channelId] = [channelHandlers];
+    }
+  });
 };
 
 const handleMessage = async (message: Message) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import autodelete from "./features/autodelete-spam";
 import { ChannelHandlers } from "./types";
 import { scheduleMessages } from "./features/scheduled-messages";
 import tsPlaygroundLinkShortener from "./features/tsplay";
+import { CHANNELS } from "./constants";
 
 export const bot = new discord.Client({
   intents: [
@@ -145,7 +146,7 @@ if (process.env.BOT_LOG) {
 setupStats(bot);
 
 // reactiflux
-addHandler("103882387330457600", jobs);
+addHandler(CHANNELS.jobBoard, jobs);
 
 // common
 addHandler("*", [


### PR DESCRIPTION
This partially addresses the points in #134. It doesn't support timed closing, messaging to the thread on close, or adding a `!close` command, but it does enforce that threads must be used in a specific channel!

The rules:

* Top-level messages will have threads created with the name `name – time date`
* Replies to the message are deleted, with the messaged DM'd to the sender
* Replies to your own messages are _not_ removed (they stick around), intended to allow "followup" questions to be linked together

Video preview:

https://user-images.githubusercontent.com/1551487/147841572-bbd8362a-3ea8-45f3-a4d5-ea2c57c77db2.mov





(This is a stacked diff off #146)