### PR TITLE
Kick spammers instead of banning

### DIFF
--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -12,7 +12,7 @@ import { constructLog, simplifyString } from "../helpers/modLog";
 import { isStaff } from "../helpers/discord";
 import { partition } from "../helpers/array";
 
-const AUTOBAN_SPAM_THRESHOLD = 5;
+const AUTO_SPAM_THRESHOLD = 5;
 const config = {
   // This is how many ️️warning reactions a post must get until it's considered an official warning
   warningThreshold: 1,
@@ -145,11 +145,11 @@ Thanks!
       ),
     );
 
-    if (warnings >= AUTOBAN_SPAM_THRESHOLD) {
+    if (warnings >= AUTO_SPAM_THRESHOLD) {
       guild.members.fetch(message.author.id).then((member) => {
-        member.ban({ reason: "Autobanned for spamming" });
+        member.kick("Autokicked for spamming");
         logChannel.send(
-          `Automatically banned <@${message.author.id}> for spam`,
+          `Automatically kicked <@${message.author.id}> for spam`,
         );
       });
     }

--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -59,7 +59,7 @@ const handleReport = (
 
     let finalLog = logBody;
     // If this was a mod report, increment the warning count
-    if (reason === ReportReasons.mod) {
+    if (reason === ReportReasons.mod || reason === ReportReasons.spam) {
       finalLog = logBody.replace(/warned \d times/, `warned ${warnings} times`);
     }
 


### PR DESCRIPTION
Also some small refactors. I just can't help myself.

* Kick instead of banning users reported for spam. This reduces our mod burden, cuz folks who get compromised can rejoin after locking down their account again. Since we already delete these messages, it won't matter if they continually join and spam, cuz it won't be seen by most members. If spammers start getting around our deletion, we might need to reconsider
* Fix a bug where spam reports don't update the warning to display number of reports
* Change `handleReport` to return the number of warnings, which let me…
* Move "auto kick" logic out of handleReport and into the spam emoji handler