### PR TITLE
Give a short-lived instruction at the start of every thread

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const enum CHANNELS {
   "random" = "103325358643752960",
   "jobBoard" = "103882387330457600",
   "modLog" = "257930126145224704",
+  "thanks" = "798567961468076072",
 }
 
 export const enum ReportReasons {

--- a/src/features/autothread.ts
+++ b/src/features/autothread.ts
@@ -1,5 +1,6 @@
 import { differenceInHours, format } from "date-fns";
 import { Client, Message, PartialMessage } from "discord.js";
+import { CHANNELS } from "../constants";
 import { constructDiscordLink } from "../helpers/discord";
 import { sleep } from "../helpers/misc";
 import { ChannelHandlers } from "../types";
@@ -64,7 +65,7 @@ const autoThread: ChannelHandlers = {
       name: `${msg.author.username} – ${format(new Date(), "HH-mm MMM d")}`,
     });
     const message = await newThread.send(
-      "React to someone with ✅ to mark their response as the accepted answer and close this thread",
+      `React to someone with ✅ to mark their response as the accepted answer and close this thread. If someone has been really helpful, give them a shoutout in <#${CHANNELS.thanks}>!`,
     );
     await sleep(30);
     message.delete();

--- a/src/features/autothread.ts
+++ b/src/features/autothread.ts
@@ -60,9 +60,14 @@ const autoThread: ChannelHandlers = {
         return;
       }
     }
-    msg.startThread({
+    const newThread = await msg.startThread({
       name: `${msg.author.username} – ${format(new Date(), "HH-mm MMM d")}`,
     });
+    const message = await newThread.send(
+      "React to someone with ✅ to mark their response as the accepted answer and close this thread",
+    );
+    await sleep(30);
+    message.delete();
   },
   handleReaction: async ({ reaction }) => {
     if (!CHECKS.includes(reaction.emoji.toString())) {


### PR DESCRIPTION
This posts an instructional message at the start of every thread, then deletes it after 30 seconds

> React to someone with ✅ to mark their response as the accepted answer and close this thread