### PR TITLE
Use parent channel id for metrics on messages sent in threads

### DIFF
--- a/src/features/stats.ts
+++ b/src/features/stats.ts
@@ -47,14 +47,19 @@ const stats = (client: Client) => {
     emitEvent(EVENTS.memberLeft);
   });
 
-  client.on("messageCreate", (msg) => {
+  client.on("messageCreate", async (msg) => {
     const { member, author, channel, content } = msg;
 
     if (!channel || !author || author.id === client.user?.id) return;
 
+    const channelId =
+      channel.isThread() && channel.parent
+        ? (await channel.parent.fetch()).id
+        : channel.id;
+
     emitEvent(EVENTS.message, {
       data: {
-        channel: channel.id,
+        channel: channelId,
         messageLength: content?.length ?? 0,
         roles: member
           ? [...member.roles.cache.values()]


### PR DESCRIPTION
Going to merge this quickly because it affects data collection.

Our "channel activity" dashboards are showing `#help-js` at ~ 0 activity, since the channel id being tracked is from the thread. That's not helpful, so use the parent channel id.