### PR TITLE
Improve auto thread experience

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,5 @@
 export const modRoleId = "&102870499406647296";
 
-export const staffRoles = ["mvp", "moderator", "admin", "admins"];
-
 export const enum CHANNELS {
   "helpReact" = "103696749012467712",
   "helpThreadsReact" = "902647189120118794",

--- a/src/features/autothread.ts
+++ b/src/features/autothread.ts
@@ -121,12 +121,16 @@ export const cleanupThreads = async (channelIds: string[], bot: Client) => {
           .send({
             content: `This thread hasn’t had any activity in ${IDLE_TIMEOUT} hours, so it’s now locked.
 
+Threads are closed automatically after ${IDLE_TIMEOUT} hours. If you have a followup question, you may want to reply to this thread so other members know they're related. ${constructDiscordLink(
+              starter,
+            )}
+
 ${
-  toCompare === starter
+  toCompare.content === ""
     ? `Question not getting answered? Maybe it's hard to answer, or maybe you asked at a slow time. Check out these resources for help asking a good question:
 
-https://stackoverflow.com/help/how-to-ask
-http://wp.me/p2oIwo-26`
+<https://stackoverflow.com/help/how-to-ask>
+<http://wp.me/p2oIwo-26>`
     : ""
 }`,
           })

--- a/src/features/autothread.ts
+++ b/src/features/autothread.ts
@@ -100,7 +100,14 @@ export const cleanupThreads = async (channelIds: string[], bot: Client) => {
           .send({
             content: `This thread hasn’t had any activity in ${IDLE_TIMEOUT} hours, so it’s now locked.
 
-Threads are closed automatically after ${IDLE_TIMEOUT} hours, or if the member who started it reacts to a message with ✅ to mark that as the accepted answer.`,
+${
+  toCompare === starter
+    ? `Question not getting answered? Maybe it's hard to answer, or maybe you asked at a slow time. Check out these resources for help asking a good question:
+
+https://stackoverflow.com/help/how-to-ask
+http://wp.me/p2oIwo-26`
+    : ""
+}`,
           })
           .then(() => {
             thread.setLocked(true);

--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -9,7 +9,7 @@ import cooldown from "./cooldown";
 import { ChannelHandlers } from "../types";
 import { CHANNELS, ReportReasons } from "../constants";
 import { constructLog, simplifyString } from "../helpers/modLog";
-import { isStaff } from "../helpers/discord";
+import { fetchReactionMembers, isStaff } from "../helpers/discord";
 import { partition } from "../helpers/array";
 
 const AUTO_SPAM_THRESHOLD = 5;
@@ -212,14 +212,14 @@ const emojiMod: ChannelHandlers = {
       return;
     }
 
-    const [fullReaction, fullMessage, reactor, authorMember, usersWhoReacted] =
+    const [fullReaction, fullMessage, reactor, authorMember] =
       await Promise.all([
         reaction.partial ? reaction.fetch() : reaction,
         message.partial ? message.fetch() : message,
         guild.members.fetch(user.id),
         guild.members.fetch(author.id),
-        Promise.all(users.cache.map((user) => guild.members.fetch(user.id))),
       ]);
+    const usersWhoReacted = await fetchReactionMembers(guild, fullReaction);
 
     reactionHandlers[emoji]?.({
       guild,

--- a/src/features/stats.ts
+++ b/src/features/stats.ts
@@ -2,11 +2,8 @@ import fetch from "node-fetch";
 import queryString from "query-string";
 import { Client } from "discord.js";
 
-type EmitEventData = {
-  channel: string; // channel ID
-  messageLength: number;
-  roles: string[];
-};
+type AmplitudeValue = string | number | boolean;
+type EmitEventData = Record<string, AmplitudeValue | AmplitudeValue[]>;
 
 const emitEvent = (
   eventName: string,
@@ -32,19 +29,32 @@ const emitEvent = (
   fetch(`https://api.amplitude.com/httpapi?${queryString.stringify(fields)}`);
 };
 
-const EVENTS = {
-  message: "message sent",
-  newMember: "new member joined",
-  memberLeft: "member left server",
+const message = "message sent";
+const newMember = "new member joined";
+const memberLeft = "member left server";
+const threadCreated = "thread created";
+const threadReplyRemoved = "thread reply removed";
+const threadTimeout = "thread timeout";
+const threadResolved = "thread resolved";
+
+export const threadStats = {
+  threadCreated: (channel: string) =>
+    emitEvent(threadCreated, { data: { channel } }),
+  threadReplyRemoved: (channel: string) =>
+    emitEvent(threadReplyRemoved, { data: { channel } }),
+  threadTimeout: (channel: string) =>
+    emitEvent(threadTimeout, { data: { channel } }),
+  threadResolved: (channel: string, userId: string) =>
+    emitEvent(threadResolved, { data: { channel, userId } }),
 };
 
 const stats = (client: Client) => {
   client.on("guildMemberAdd", () => {
-    emitEvent(EVENTS.newMember);
+    emitEvent(newMember);
   });
 
   client.on("guildMemberRemove", () => {
-    emitEvent(EVENTS.memberLeft);
+    emitEvent(memberLeft);
   });
 
   client.on("messageCreate", async (msg) => {
@@ -57,7 +67,7 @@ const stats = (client: Client) => {
         ? (await channel.parent.fetch()).id
         : channel.id;
 
-    emitEvent(EVENTS.message, {
+    emitEvent(message, {
       data: {
         channel: channelId,
         messageLength: content?.length ?? 0,

--- a/src/features/stats.ts
+++ b/src/features/stats.ts
@@ -44,8 +44,14 @@ export const threadStats = {
     emitEvent(threadReplyRemoved, { data: { channel } }),
   threadTimeout: (channel: string) =>
     emitEvent(threadTimeout, { data: { channel } }),
-  threadResolved: (channel: string, userId: string) =>
-    emitEvent(threadResolved, { data: { channel, userId } }),
+  threadResolved: (
+    channel: string,
+    threadAuthor: string,
+    answerAuthor: string,
+  ) =>
+    emitEvent(threadResolved, {
+      data: { channel, threadAuthor, answerAuthor },
+    }),
 };
 
 const stats = (client: Client) => {

--- a/src/helpers/discord.ts
+++ b/src/helpers/discord.ts
@@ -6,14 +6,27 @@ import {
   MessageReaction,
   PartialMessageReaction,
 } from "discord.js";
-import { staffRoles } from "../constants";
+
+const staffRoles = ["mvp", "moderator", "admin", "admins"];
+const helpfulRoles = ["mvp", "star helper"];
+
+const hasRole = (member: GuildMember, roles: string | string[]) =>
+  member.roles.cache.some((role) => {
+    const normalizedRole = role.name.toLowerCase();
+    return typeof roles === "string"
+      ? roles === normalizedRole
+      : roles.includes(normalizedRole);
+  });
 
 export const isStaff = (member: GuildMember | null | undefined) => {
   if (!member) return false;
 
-  return member.roles.cache.some((role) =>
-    staffRoles.includes(role.name.toLowerCase()),
-  );
+  return hasRole(member, staffRoles);
+};
+export const isHelpful = (member: GuildMember | null | undefined) => {
+  if (!member) return false;
+
+  return hasRole(member, helpfulRoles);
 };
 
 export const constructDiscordLink = (message: Message | PartialMessage) =>

--- a/src/helpers/discord.ts
+++ b/src/helpers/discord.ts
@@ -36,4 +36,8 @@ export const fetchReactionMembers = (
   guild: Guild,
   reaction: MessageReaction | PartialMessageReaction,
 ) =>
-  Promise.all(reaction.users.cache.map((user) => guild.members.fetch(user.id)));
+  reaction.users
+    .fetch()
+    .then((users) =>
+      Promise.all(users.map((user) => guild.members.fetch(user.id))),
+    );

--- a/src/helpers/discord.ts
+++ b/src/helpers/discord.ts
@@ -1,4 +1,11 @@
-import { Message, GuildMember, PartialMessage } from "discord.js";
+import {
+  Message,
+  GuildMember,
+  PartialMessage,
+  Guild,
+  MessageReaction,
+  PartialMessageReaction,
+} from "discord.js";
 import { staffRoles } from "../constants";
 
 export const isStaff = (member: GuildMember | null | undefined) => {
@@ -11,3 +18,9 @@ export const isStaff = (member: GuildMember | null | undefined) => {
 
 export const constructDiscordLink = (message: Message | PartialMessage) =>
   `https://discord.com/channels/${message.guild?.id}/${message.channel.id}/${message.id}`;
+
+export const fetchReactionMembers = (
+  guild: Guild,
+  reaction: MessageReaction | PartialMessageReaction,
+) =>
+  Promise.all(reaction.users.cache.map((user) => guild.members.fetch(user.id)));


### PR DESCRIPTION
* Emit metrics so we can track activity
* Allow members with helpful roles + staff to mark questions as answered
* Don't lock threads when answers are marked
* Share links to "how to ask good questions" resources if the thread was closed without any messages