### PR TITLE
Fix flaky reaction handling by always fetching message author

### DIFF
--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -223,6 +223,8 @@ const emojiMod: ChannelHandlers = {
       guild.members.fetch(fullMessage.author.id),
     ]);
 
+    if (authorMember.id === bot.user?.id) return;
+
     reactionHandlers[emoji]?.({
       guild,
       author: authorMember,

--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -197,9 +197,9 @@ Thanks!
 const emojiMod: ChannelHandlers = {
   handleReaction: async ({ reaction, user, bot }) => {
     const { message } = reaction;
-    const { author, guild } = message;
+    const { guild } = message;
 
-    if (!guild || !author || author?.id === bot.user?.id) {
+    if (!guild) {
       return;
     }
 
@@ -213,14 +213,15 @@ const emojiMod: ChannelHandlers = {
       return;
     }
 
-    const [fullReaction, fullMessage, reactor, authorMember] =
-      await Promise.all([
-        reaction.partial ? reaction.fetch() : reaction,
-        message.partial ? message.fetch() : message,
-        guild.members.fetch(user.id),
-        guild.members.fetch(author.id),
-      ]);
-    const usersWhoReacted = await fetchReactionMembers(guild, fullReaction);
+    const [fullReaction, fullMessage, reactor] = await Promise.all([
+      reaction.partial ? reaction.fetch() : reaction,
+      message.partial ? message.fetch() : message,
+      guild.members.fetch(user.id),
+    ]);
+    const [usersWhoReacted, authorMember] = await Promise.all([
+      fetchReactionMembers(guild, fullReaction),
+      guild.members.fetch(fullMessage.author.id),
+    ]);
 
     reactionHandlers[emoji]?.({
       guild,


### PR DESCRIPTION
We've had some flaky handling for ⚠️ reactions lately, it looks like it comes down to whether the message was sent before or after the bot was restarted because the message author wouldn't be cached. By always fetching the author, it should be more reliable