### PR TITLE
added Code of Conduct command

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -45,6 +45,23 @@ const commandsList: Command[] = [
     },
   },
   {
+    words: [`!conduct`],
+    help: `informs user's of code of conduct`,
+    category: "Reactiflux",
+    handleMessage: (msg) => {
+      msg.reply({
+        embeds: [
+          {
+            title: "Code of Conduct",
+            type: "rich",
+            description: `Reactiflux is the largest chat community of React developers. We make a deliberate effort to have a light touch when it comes to moderating, but we do have some expectations of how our members will behave. Please read the full Code of Conduct at https://www.reactiflux.com/conduct`,
+            color: EMBED_COLOR,
+          },
+        ],
+      });
+    },
+  },
+  {
     words: [`!rrlinks`],
     help: `shares a repository of helpful links regarding React and Redux`,
     category: "React/Redux",


### PR DESCRIPTION
I find that it is a useful reminder when users are being inappropriate to remind them (or inform them) of the server's Code of Conduct. When doing so I usually have to open a new tab and search for it. It would be useful to have it as a command so that it can be easily accessible and more often remind users about them.