### PR TITLE
added self-promotion guidelines command

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -62,6 +62,25 @@ const commandsList: Command[] = [
     },
   },
   {
+    words: [`!promotion`],
+    help: `informs user's of self-promotion guidelines`,
+    category: "Reactiflux",
+    handleMessage: (msg) => {
+      msg.reply({
+        embeds: [
+          {
+            title: "Self Promotion",
+            type: "rich",
+            description: `Reactiflux's members do lots of cool stuff, and we'd love for you to share what you've done! However Reactiflux is fundamentally a peer group, not an advertising channel or a free audience. Members who join only to promote something have what they share more aggressively moderated than members who participate in the community in other ways.
+            
+            Please review our guidelines around self-promotion at https://www.reactiflux.com/promotion`,
+            color: EMBED_COLOR,
+          },
+        ],
+      });
+    },
+  },
+  {
     words: [`!rrlinks`],
     help: `shares a repository of helpful links regarding React and Redux`,
     category: "React/Redux",

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -71,9 +71,7 @@ const commandsList: Command[] = [
           {
             title: "Self Promotion",
             type: "rich",
-            description: `Reactiflux's members do lots of cool stuff, and we'd love for you to share what you've done! However Reactiflux is fundamentally a peer group, not an advertising channel or a free audience. Members who join only to promote something have what they share more aggressively moderated than members who participate in the community in other ways.
-            
-            Please review our guidelines around self-promotion at https://www.reactiflux.com/promotion`,
+            description: `Reactiflux is a peer group, not an advertising channel or a free audience. Please review our guidelines around self-promotion at https://www.reactiflux.com/promotion`,
             color: EMBED_COLOR,
           },
         ],


### PR DESCRIPTION
Similar to the `!conduct` command, this will add the `!promotion` command to remind users of the guidelines around self-promotion. I saw the need for it in this message:

![Screen Shot 2022-02-10 at 6 40 50 PM](https://user-images.githubusercontent.com/45526432/153515493-74d8c899-1091-4082-b07f-4d760d26bee1.png)