### PR TITLE
Add env detection to switch channel constants automatically

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -58,14 +58,13 @@ jobs:
           AMPLITUDE_KEY: ${{ secrets.AMPLITUDE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_HASH: ${{ secrets.DISCORD_HASH }}
-          BOT_LOG: ${{ secrets.BOT_LOG }}
         with:
           host: ${{ secrets.SSH_HOST }}
           username: root
           key: ${{ secrets.SSH_KEY }}
-          envs: AMPLITUDE_KEY,GITHUB_TOKEN,DISCORD_HASH,GITHUB_HEAD_REF,BOT_LOG
+          envs: AMPLITUDE_KEY,GITHUB_TOKEN,DISCORD_HASH,GITHUB_HEAD_REF
           script: |
             sudo docker container stop $(sudo docker container ls -aq)
             sudo docker container rm $(sudo docker container ls -aq)
             sudo docker image prune -f
-            sudo docker run -d -e ENVIRONMENT=production -e AMPLITUDE_KEY=$AMPLITUDE_KEY -e GITHUB_TOKEN=$GITHUB_TOKEN -e DISCORD_HASH=$DISCORD_HASH -e BOT_LOG=$BOT_LOG reactiflux/reactibot:latest
+            sudo docker run -d -e ENVIRONMENT=production -e AMPLITUDE_KEY=$AMPLITUDE_KEY -e GITHUB_TOKEN=$GITHUB_TOKEN -e DISCORD_HASH=$DISCORD_HASH reactiflux/reactibot:latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -68,4 +68,4 @@ jobs:
             sudo docker container stop $(sudo docker container ls -aq)
             sudo docker container rm $(sudo docker container ls -aq)
             sudo docker image prune -f
-            sudo docker run -d -e AMPLITUDE_KEY=$AMPLITUDE_KEY -e GITHUB_TOKEN=$GITHUB_TOKEN -e DISCORD_HASH=$DISCORD_HASH -e BOT_LOG=$BOT_LOG reactiflux/reactibot:latest
+            sudo docker run -d -e ENVIRONMENT=production -e AMPLITUDE_KEY=$AMPLITUDE_KEY -e GITHUB_TOKEN=$GITHUB_TOKEN -e DISCORD_HASH=$DISCORD_HASH -e BOT_LOG=$BOT_LOG reactiflux/reactibot:latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -51,9 +51,6 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           script: |
             cd reactibot
-            sudo docker container stop $(sudo docker container ls -aq)
-            sudo docker container rm $(sudo docker container ls -aq)
-            sudo docker image prune -f
             sudo docker build -t reactiflux/reactibot:latest .
       - name: Start server
         uses: appleboy/ssh-action@master
@@ -68,4 +65,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           envs: AMPLITUDE_KEY,GITHUB_TOKEN,DISCORD_HASH,GITHUB_HEAD_REF,BOT_LOG
           script: |
+            sudo docker container stop $(sudo docker container ls -aq)
+            sudo docker container rm $(sudo docker container ls -aq)
+            sudo docker image prune -f
             sudo docker run -d -e AMPLITUDE_KEY=$AMPLITUDE_KEY -e GITHUB_TOKEN=$GITHUB_TOKEN -e DISCORD_HASH=$DISCORD_HASH -e BOT_LOG=$BOT_LOG reactiflux/reactibot:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build/reactibot
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
-COPY package*.json ./
+COPY package.json yarn.lock ./
 
 RUN yarn
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,16 +2,6 @@ export const modRoleId = "&102870499406647296";
 
 export const guildId = "102860784329052160";
 
-export const enum CHANNELS {
-  "helpReact" = "103696749012467712",
-  "helpThreadsReact" = "902647189120118794",
-  "helpJs" = "565213527673929729",
-  "random" = "103325358643752960",
-  "jobBoard" = "103882387330457600",
-  "modLog" = "591326408396111907",
-  "thanks" = "798567961468076072",
-}
-
 export const enum ReportReasons {
   userWarn = "userWarn",
   userDelete = "userDelete",

--- a/src/constants/channels.ts
+++ b/src/constants/channels.ts
@@ -1,0 +1,25 @@
+import { isProd } from "../helpers/env";
+
+const LOCAL_CHANNELS: Record<keyof typeof PRODUCTION_CHANNELS, string> = {
+  helpReact: "926931785219207301",
+  helpThreadsReact: "926931785219207301",
+  helpJs: "926931785219207301",
+  random: "926931785219207301",
+  thanks: "926931785219207301",
+  jobBoard: "925847361996095509",
+  modLog: "257930126145224704",
+  botLog: "916081991542276096",
+};
+
+const PRODUCTION_CHANNELS = {
+  helpReact: "103696749012467712",
+  helpThreadsReact: "902647189120118794",
+  helpJs: "565213527673929729",
+  random: "103325358643752960",
+  thanks: "798567961468076072",
+  jobBoard: "103882387330457600",
+  modLog: "257930126145224704",
+  botLog: "701462381703856158",
+};
+
+export const CHANNELS = isProd() ? PRODUCTION_CHANNELS : LOCAL_CHANNELS;

--- a/src/constants/channels.ts
+++ b/src/constants/channels.ts
@@ -7,7 +7,7 @@ const LOCAL_CHANNELS: Record<keyof typeof PRODUCTION_CHANNELS, string> = {
   random: "926931785219207301",
   thanks: "926931785219207301",
   jobBoard: "925847361996095509",
-  modLog: "257930126145224704",
+  modLog: "925847644318879754",
   botLog: "916081991542276096",
 };
 

--- a/src/features/autothread.ts
+++ b/src/features/autothread.ts
@@ -1,6 +1,6 @@
 import { differenceInHours, format } from "date-fns";
 import { Client } from "discord.js";
-import { CHANNELS } from "../constants";
+import { CHANNELS } from "../constants/channels";
 import {
   constructDiscordLink,
   fetchReactionMembers,

--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -7,7 +7,8 @@ import {
 } from "discord.js";
 import cooldown from "./cooldown";
 import { ChannelHandlers } from "../types";
-import { CHANNELS, ReportReasons } from "../constants";
+import { ReportReasons } from "../constants";
+import { CHANNELS } from "../constants/channels";
 import { constructLog } from "../helpers/modLog";
 import { simplifyString } from "../helpers/string";
 import { fetchReactionMembers, isStaff } from "../helpers/discord";

--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -1,6 +1,6 @@
 import { compareAsc, differenceInDays, format } from "date-fns";
 import { Client, Message, TextChannel } from "discord.js";
-import { CHANNELS } from "../constants";
+import { CHANNELS } from "../constants/channels";
 import { isStaff } from "../helpers/discord";
 import { sleep } from "../helpers/misc";
 import cooldown from "./cooldown";

--- a/src/features/scheduled-messages.ts
+++ b/src/features/scheduled-messages.ts
@@ -1,5 +1,6 @@
 import type * as discord from "discord.js";
-import { guildId as defaultGuildId, CHANNELS } from "../constants";
+import { guildId as defaultGuildId } from "../constants";
+import { CHANNELS } from "../constants/channels";
 import { logger } from "./log";
 import { scheduleTask } from "../helpers/schedule";
 

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -1,0 +1,7 @@
+const enum ENVIONMENTS {
+  production = "production",
+}
+
+export const isProd = () => process.env.ENVIRONMENT === ENVIONMENTS.production;
+
+console.log("Running as", isProd() ? "PRODUCTION" : "TEST", "environment");

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import autothread, { cleanupThreads } from "./features/autothread";
 import { ChannelHandlers } from "./types";
 import { scheduleMessages } from "./features/scheduled-messages";
 import tsPlaygroundLinkShortener from "./features/tsplay";
-import { CHANNELS } from "./constants";
+import { CHANNELS } from "./constants/channels";
 import { scheduleTask } from "./helpers/schedule";
 
 export const bot = new discord.Client({

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,9 +143,7 @@ const handleReaction = (
 };
 
 logger.add(stdoutLog);
-if (process.env.BOT_LOG) {
-  logger.add(channelLog(bot, process.env.BOT_LOG)); // #bot-log
-}
+logger.add(channelLog(bot, CHANNELS.botLog));
 
 // Amplitude metrics
 setupStats(bot);


### PR DESCRIPTION
Also a couple of small fixes:

* Move stop/clean docker commands so there isn't a delay of few seconds where the bot isn't running
* Fix docker build to include `yarn.lock`
* Use `CHANNELS.botLog` instead of loading it from an environment variable