### PR TITLE
Update !lift link to new docs

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -237,7 +237,7 @@ Check out https://reactkungfu.com/2015/07/why-and-how-to-bind-methods-in-your-re
             type: "rich",
             description: `Often, several components need to reflect the same changing data. We recommend lifting the shared state up to their closest common ancestor. Let’s see how this works in action.
 
-https://reactjs.org/docs/lifting-state-up.html`,
+https://beta.reactjs.org/learn/sharing-state-between-components`,
             color: EMBED_COLOR,
           },
         ],


### PR DESCRIPTION
"Lifting state up" was renamed in the new docs to "Sharing state between components" - https://beta.reactjs.org/learn/sharing-state-between-components - the spirit of the doc page is the same and I believe people here remember the `!lift` command, so I wouldn't change the command itself, just the link to the doc page.

Discussed in https://discord.com/channels/102860784329052160/955495969628233748