### PR TITLE
Add anonymous message reporting mechanism

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -49,7 +49,7 @@ jobs:
             cd reactibot
             sudo docker build -t reactiflux/reactibot:latest .
       - name: Deploy Discord commands
-        uses: applyboy/ssh-action@master
+        uses: appleboy/ssh-action@master
         env:
           DISCORD_HASH: ${{ secrets.DISCORD_HASH }}
         with:

--- a/scripts/deploy-commands.ts
+++ b/scripts/deploy-commands.ts
@@ -12,6 +12,8 @@ import { applicationId, discordToken, guildId } from "../src/constants";
 import { logger } from "../src/features/log";
 import { difference } from "../src/helpers/sets";
 
+import * as report from "../src/commands/report";
+
 // TODO: make this a global command in production
 const upsertUrl = () => Routes.applicationGuildCommands(applicationId, guildId);
 const deleteUrl = (commandId: string) =>
@@ -22,7 +24,7 @@ interface CommandConfig {
   description: string;
   type: ApplicationCommandType;
 }
-const cmds: CommandConfig[] = [];
+const cmds: CommandConfig[] = [report];
 
 const commands = [
   ...cmds

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -1,0 +1,21 @@
+import { ApplicationCommandType } from "discord-api-types/v9";
+import { Message, MessageContextMenuInteraction } from "discord.js";
+import { ReportReasons } from "../constants";
+import { constructLog, reportUser } from "../helpers/modLog";
+
+export const name = "report-message";
+export const description = "Anonymously report this message";
+export const type = ApplicationCommandType.Message;
+export const handler = async (interaction: MessageContextMenuInteraction) => {
+  const message = interaction.targetMessage;
+  if (!(message instanceof Message)) {
+    return;
+  }
+
+  reportUser(message, constructLog(ReportReasons.anonReport, [], [], message));
+
+  await interaction.reply({
+    ephemeral: true,
+    content: "This message has been reported anonymously",
+  });
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const gitHubToken = process.env.GITHUB_TOKEN ?? "";
 export const amplitudeKey = process.env.AMPLITUDE_KEY ?? "";
 
 export const enum ReportReasons {
+  anonReport = "anonReport",
   userWarn = "userWarn",
   userDelete = "userDelete",
   mod = "mod",

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -1,9 +1,22 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import fetch from "node-fetch";
-import { Message, TextChannel } from "discord.js";
+import { Client, Message, TextChannel } from "discord.js";
 import cooldown from "./cooldown";
 import { ChannelHandlers } from "../types";
 import { isStaff } from "../helpers/discord";
+
+import * as report from "../commands/report";
+
+export const setupInteractions = (bot: Client) => {
+  bot.on("interactionCreate", (interaction) => {
+    if (interaction.isMessageContextMenu()) {
+      switch (interaction.commandName) {
+        case report.name:
+          return report.handler(interaction);
+      }
+    }
+  });
+};
 
 export const EMBED_COLOR = 7506394;
 

--- a/src/helpers/modLog.ts
+++ b/src/helpers/modLog.ts
@@ -1,6 +1,48 @@
-import { Message } from "discord.js";
+import { Message, TextChannel } from "discord.js";
 import { ReportReasons, modRoleId } from "../constants";
 import { constructDiscordLink } from "./discord";
+import { simplifyString } from "../helpers/string";
+
+const warningMessages = new Map<
+  string,
+  { warnings: number; message: Message }
+>();
+export const reportUser = (
+  reason: ReportReasons,
+  channelInstance: TextChannel,
+  reportedMessage: Message,
+  logBody: string,
+) => {
+  const simplifiedContent = `${reportedMessage.author.id}${simplifyString(
+    reportedMessage.content,
+  )}`;
+  const cached = warningMessages.get(simplifiedContent);
+
+  if (cached) {
+    // If we already logged for ~ this message, edit the log
+    const { message, warnings: oldWarnings } = cached;
+    const warnings = oldWarnings + 1;
+
+    let finalLog = logBody;
+    // If this was a mod report, increment the warning count
+    if (reason === ReportReasons.mod || reason === ReportReasons.spam) {
+      finalLog = logBody.replace(/warned \d times/, `warned ${warnings} times`);
+    }
+
+    message.edit(finalLog);
+    warningMessages.set(simplifiedContent, { warnings, message });
+    return warnings;
+  } else {
+    // If this is new, send a new message
+    channelInstance.send(logBody).then((warningMessage) => {
+      warningMessages.set(simplifiedContent, {
+        warnings: 1,
+        message: warningMessage,
+      });
+    });
+    return 1;
+  }
+};
 
 // Discord's limit for message length
 const maxMessageLength = 2000;

--- a/src/helpers/modLog.ts
+++ b/src/helpers/modLog.ts
@@ -57,7 +57,7 @@ export const constructLog = (
   members: string[],
   staff: string[],
   message: Message,
-) => {
+): string => {
   const modAlert = `<@${modRoleId}>`;
   const preface = `<@${message.author.id}> in <#${message.channel.id}> warned 1 times`;
   const postfix = `Link: ${constructDiscordLink(message)}
@@ -90,6 +90,12 @@ ${postfix}`;
 ${postfix}`;
     case ReportReasons.spam:
       return `${preface}, reported for spam:
+
+\`${reportedMessage}\`
+
+${postfix}`;
+    case ReportReasons.anonReport:
+      return `${preface}, reported anonymously:
 
 \`${reportedMessage}\`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { logger, channelLog } from "./features/log";
 // import codeblock from './features/codeblock';
 import jobsMod from "./features/jobs-moderation";
 import autoban from "./features/autoban";
-import commands from "./features/commands";
+import commands, { setupInteractions } from "./features/commands";
 import setupStats from "./features/stats";
 import emojiMod from "./features/emojiMod";
 import autodelete from "./features/autodelete-spam";
@@ -149,6 +149,9 @@ logger.add(channelLog(bot, CHANNELS.botLog));
 
 // Amplitude metrics
 setupStats(bot);
+
+// Discord commands
+setupInteractions(bot);
 
 // common
 addHandler("*", [


### PR DESCRIPTION
Currently, moderators can use a ⚠️ reaction to log a message and MVPs/other members can use 👎 to report inappropriate messages, but both of these expose the name of the user who reacted.

This builds on support for Application Commands (#198) to add an option to any message's context menu, allowing it to be reported entirely anonymously.

I opted not to track the name of who reported in #mod-log, since it's advertised as "anonymously report". We can reconsider if it's a problem.

<img width="469" alt="Screen Shot 2022-03-22 at 1 23 39 PM" src="https://user-images.githubusercontent.com/1551487/159539409-b2fbe47b-06e4-453e-a0de-84d481e22d06.png">
<img width="444" alt="Screen Shot 2022-03-22 at 12 39 26 PM" src="https://user-images.githubusercontent.com/1551487/159539233-ae024282-2c3c-4574-95a3-5fc8f7a1bf20.png">
<img width="588" alt="Screen Shot 2022-03-22 at 12 39 17 PM" src="https://user-images.githubusercontent.com/1551487/159539245-2067e7df-b598-4301-b3cf-ce9926d90b8c.png">

