### PR TITLE
Run CI build with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .env
 .env*
+dist
+.github

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,6 @@
 name: Node.js CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,6 +25,8 @@ jobs:
           tags: |
             type=ref,event=pr
             type=ref,event=branch
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -32,7 +32,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # push: ${{ github.event_name != 'pull_request' }}
-          push: true
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -14,8 +17,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout
-        uses: actions/checkout@v2
 
       - name: Setup tags
         run: |

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,14 +7,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install
-        run: yarn --ci
-      - name: Test
-        run: yarn test
-      - name: Build
-        run: yarn build
+
+      - name: Setup tags
+        run: |
+          export COMMIT_HASH=`git log -1 --pretty=%h`
+          echo "TAGS=ghcr.io/$GITHUB_REPOSITORY:$COMMIT_HASH,ghcr.io/$GITHUB_REPOSITORY:latest" >> $GITHUB_ENV
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2.10.0
+        with:
+          context: .
+          push: true
+          tags: ${{ env.TAGS }}
 
   deployment:
     needs: build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,20 +15,24 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
 
-
-      - name: Setup tags
-        run: |
-          export COMMIT_HASH=`git log -1 --pretty=%h`
-          echo "TAGS=ghcr.io/$GITHUB_REPOSITORY:$COMMIT_HASH,ghcr.io/$GITHUB_REPOSITORY:latest" >> $GITHUB_ENV
+      - name: Tag Build
+        uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@v2
         with:
-          context: .
+          # push: ${{ github.event_name != 'pull_request' }}
           push: true
-          tags: ${{ env.TAGS }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   deployment:
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,11 @@ COPY package.json yarn.lock ./
 
 RUN yarn
 
-COPY . .
+COPY tsconfig.json .eslint* .prettierignore ./
+COPY src ./src
+COPY scripts ./scripts
 
+RUN yarn test
 RUN yarn build
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
Our "build" step is currently redundant, it installs/builds/tests, which allows the deployment step to install/build/run. If we uploaded docker images as a build artifact from this CI step, we could reuse it when deploying code.

I want to make that transition in several parts:

* (this PR) swap out "build" step to use docker and add ability to upload docker images (currently disabled as its unused)
* swap out deploy step to use the docker image built from CI
* (stretch) reduce custom deploy code and use more powerful build primitives. We're SSHing into a DO Droplet and running some commands directly on the server. DO exposes a managed Kubernetes product that looks pretty cheap and simple — if we could replace "ssh into a server and run docker" with "stand up a new k8s deployment," that would enable a lot more powerful work in the future

Major kudos to @taranvohra for getting a first draft of this working, and pointing out a bunch of dumb errors I made along the way.

