### PR TITLE
Improve mod logs when job board automod reacts

### DIFF
--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -1,7 +1,6 @@
 import { ApplicationCommandType } from "discord-api-types/v9";
 import { Message, MessageContextMenuInteraction } from "discord.js";
-import { ReportReasons } from "../constants";
-import { constructLog, reportUser } from "../helpers/modLog";
+import { ReportReasons, reportUser } from "../helpers/modLog";
 
 export const name = "report-message";
 export const description = "Anonymously report this message";
@@ -12,7 +11,7 @@ export const handler = async (interaction: MessageContextMenuInteraction) => {
     return;
   }
 
-  reportUser(message, constructLog(ReportReasons.anonReport, [], [], message));
+  reportUser({ reason: ReportReasons.anonReport, message });
 
   await interaction.reply({
     ephemeral: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,11 +13,3 @@ export const guildId = isProd() ? "102860784329052160" : "614601782152265748";
 export const discordToken = process.env.DISCORD_HASH ?? "";
 export const gitHubToken = process.env.GITHUB_TOKEN ?? "";
 export const amplitudeKey = process.env.AMPLITUDE_KEY ?? "";
-
-export const enum ReportReasons {
-  anonReport = "anonReport",
-  userWarn = "userWarn",
-  userDelete = "userDelete",
-  mod = "mod",
-  spam = "spam",
-}

--- a/src/helpers/modLog.ts
+++ b/src/helpers/modLog.ts
@@ -15,17 +15,22 @@ export const enum ReportReasons {
   userDelete = "userDelete",
   mod = "mod",
   spam = "spam",
+  jobAge = "jobAge",
+  jobFrequency = "jobFrequency",
+  jobRemoved = "jobRemoved",
 }
 
 interface Report {
   reason: ReportReasons;
   message: Message;
+  extra?: string;
   staff?: GuildMember[];
   members?: GuildMember[];
 }
 export const reportUser = ({
   reason,
   message,
+  extra,
   staff = [],
   members = [],
 }: Report) => {
@@ -33,7 +38,7 @@ export const reportUser = ({
     message.content,
   )}`;
   const cached = warningMessages.get(simplifiedContent);
-  const logBody = constructLog({ reason, message, staff, members });
+  const logBody = constructLog({ reason, message, extra, staff, members });
 
   if (cached) {
     // If we already logged for ~ this message, edit the log
@@ -76,11 +81,13 @@ export const truncateMessage = (
 const constructLog = ({
   reason,
   message,
+  extra = "",
   staff = [],
   members = [],
 }: {
   reason: ReportReasons;
   message: Message;
+  extra?: string;
   staff?: GuildMember[];
   members?: GuildMember[];
 }): string => {
@@ -104,6 +111,7 @@ ${
   switch (reason) {
     case ReportReasons.mod:
       return `${preface}:
+${extra}
 
 \`${reportedMessage}\`
 
@@ -111,6 +119,7 @@ ${postfix}`;
 
     case ReportReasons.userWarn:
       return `${modAlert} – ${preface}, met the warning threshold for the message:
+${extra}
 
 \`${reportedMessage}\`
 
@@ -118,21 +127,47 @@ ${postfix}`;
 
     case ReportReasons.userDelete:
       return `${modAlert} – ${preface}, met the deletion threshold for the message:
+${extra}
 
 \`${reportedMessage}\`
 
 ${postfix}`;
+
     case ReportReasons.spam:
       return `${preface}, reported for spam:
+${extra}
 
 \`${reportedMessage}\`
 
 ${postfix}`;
+
     case ReportReasons.anonReport:
       return `${preface}, reported anonymously:
+${extra}
 
 \`${reportedMessage}\`
 
 ${postfix}`;
+
+    case ReportReasons.jobAge:
+      return `${preface}, account too young:
+${extra}
+
+\`${reportedMessage}\`
+`;
+
+    case ReportReasons.jobFrequency:
+      return `${preface}, posting too frequently:
+${extra}
+
+\`${reportedMessage}\`
+`;
+
+    case ReportReasons.jobRemoved:
+      return `${preface}, post was deleted:
+${extra}
+
+\`${reportedMessage}\`
+`;
   }
 };


### PR DESCRIPTION
Previously all removed posts were displayed with a bare ping + timestamp, now they'll have a reason as well.

old:
```
@vcarl's test account’s job post from 05/17/2022 4:10 PM was deleted
```
new:
```
@vcarl's test account in job-board warned 1 times, post was deleted:
Originally sent 05/17/2022 4:13 PM

`[hiring] butts`
```
```
@vcarl's test account in job-board warned 1 times, account too young:

[hiring] butts
```
```
@vcarl's test account in job-board warned 1 times, posting too frequently:

[hiring] butts
```