### PR TITLE
Tune down account age requirements from 3d to 1hr

### DIFF
--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -1,4 +1,9 @@
-import { compareAsc, differenceInDays, format } from "date-fns";
+import {
+  compareAsc,
+  differenceInDays,
+  differenceInHours,
+  format,
+} from "date-fns";
 import { Client, Message, TextChannel } from "discord.js";
 import { CHANNELS } from "../constants/channels";
 import { isStaff } from "../helpers/discord";
@@ -10,7 +15,7 @@ const storedMessages: Message[] = [];
 const moderatedMessageIds: Set<string> = new Set();
 
 const DAYS_OF_POSTS = 7; // days
-const MINIMUM_JOIN_AGE = 3; // days
+const MINIMUM_JOIN_AGE = 1; // hours
 
 const tags = ["forhire", "for hire", "hiring", "remote", "local"];
 
@@ -115,7 +120,7 @@ const jobModeration = async (bot: Client) => {
     const now = new Date();
     if (
       message.member?.joinedAt &&
-      differenceInDays(now, message.member.joinedAt) < MINIMUM_JOIN_AGE
+      differenceInHours(now, message.member.joinedAt) < MINIMUM_JOIN_AGE
     ) {
       moderatedMessageIds.add(message.id);
       reportUser({ reason: ReportReasons.jobAge, message });

--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -125,12 +125,12 @@ const jobModeration = async (bot: Client) => {
       moderatedMessageIds.add(message.id);
       reportUser({ reason: ReportReasons.jobAge, message });
       message.author.send(
-        "You joined too recently to post a job, please try again in a few days. Your post:",
+        "You joined too recently to post a job, please try again in a little while. Your post:",
       );
       message.author.send(message.content);
       message
         .reply(
-          "You joined too recently to post a job, please try again in a few days. Your post has been DM’d to you.",
+          "You joined too recently to post a job, please try again in a little while. Your post has been DM’d to you.",
         )
         .then(async (reply) => {
           await sleep(45);


### PR DESCRIPTION
I've noticed from mod logs that we seem to be catching up way more legitimate accounts than scammers with the account age filter. I've noted that the NFT posters I end up banning have figured out the delay, and a fair number of legitimate posters don't return. 

So, let's tune this wayyy down. 1 hour should be sufficient to encourage them to poke around the server without being so long that they completely forget