### PR TITLE
Move job board mod logs into a separate channel

### DIFF
--- a/src/constants/channels.ts
+++ b/src/constants/channels.ts
@@ -10,6 +10,7 @@ const LOCAL_CHANNELS: Record<keyof typeof PRODUCTION_CHANNELS, string> = {
   gaming: "926931785219207301",
   thanks: "926931785219207301",
   jobBoard: "925847361996095509",
+  jobsLog: "925847644318879754",
   events: "950790520811184150",
   iBuiltThis: "950790520811184150",
   iWroteThis: "950790520811184150",
@@ -27,6 +28,7 @@ const PRODUCTION_CHANNELS = {
   gaming: "509219336175747082",
   thanks: "798567961468076072",
   jobBoard: "103882387330457600",
+  jobsLog: "989201828572954694",
   events: "127442949435817984",
   iBuiltThis: "312761588778139658",
   iWroteThis: "918616846100492298",
@@ -62,7 +64,7 @@ const cachedChannels: Record<string, Record<string, TextChannel>> = {
 export const initCachedChannels = async (bot: Client) => {
   const reactiflux = await bot.guilds.fetch(guildId);
   const channels = await Promise.all(
-    [CHANNELS.botLog, CHANNELS.modLog].map((channelId) =>
+    [CHANNELS.botLog, CHANNELS.modLog, CHANNELS.jobsLog].map((channelId) =>
       reactiflux.channels.fetch(channelId),
     ),
   );

--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -129,13 +129,13 @@ const jobModeration = async (bot: Client) => {
     ) {
       moderatedMessageIds.add(message.id);
       reportUser({ reason: ReportReasons.jobAge, message });
-      message.author.send(
-        "You joined too recently to post a job, please try again in a little while. Your post:",
-      );
-      const [, reply] = await Promise.all([
-        message.author.send(message.content),
+      const [reply] = await Promise.all([
         message.reply(
           "You joined too recently to post a job, please try again in a little while. Your post has been DM’d to you.",
+        ),
+        message.author.send(message.content),
+        message.author.send(
+          "You joined too recently to post a job, please try again in a little while. Your post:",
         ),
       ]);
       await Promise.all([

--- a/src/helpers/modLog.ts
+++ b/src/helpers/modLog.ts
@@ -59,7 +59,11 @@ export const reportUser = ({
     return warnings;
   } else {
     // If this is new, send a new message
-    getChannel(CHANNELS.modLog)
+    getChannel(
+      message.channelId === CHANNELS.jobBoard
+        ? CHANNELS.jobsLog
+        : CHANNELS.modLog,
+    )
       .send(logBody)
       .then((warningMessage) => {
         warningMessages.set(simplifiedContent, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ bot.on("error", (err) => {
 
 const errorHandler = (error: unknown) => {
   if (error instanceof Error) {
-    logger.log("ERROR", error.message);
+    logger.log("ERROR", `${error.message} ${error.stack}`);
   } else if (typeof error === "string") {
     logger.log("ERROR", error);
   }


### PR DESCRIPTION
Iggy brought up that we're getting a ton of noise from the job board logging now, and it's clogging up the rest of the moderation and making us more likely to miss reports. Moving these logs into a separate channel will help us stay focused