### PR TITLE
 Block all cryptocurrency/nft/blockchain job postings

### DIFF
--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -5,11 +5,19 @@ import {
   differenceInMinutes,
   format,
 } from "date-fns";
-import { Client, Message, TextChannel } from "discord.js";
+import {
+  Client,
+  Message,
+  MessageActionRow,
+  MessageButton,
+  MessageMentions,
+  TextChannel,
+} from "discord.js";
+import { simplifyString } from "../helpers/string";
 import { CHANNELS } from "../constants/channels";
 import { isStaff } from "../helpers/discord";
 import { sleep } from "../helpers/misc";
-import { ReportReasons, reportUser } from "../helpers/modLog";
+import { ReportReasons, reportUser, modLog } from "../helpers/modLog";
 import cooldown from "./cooldown";
 
 const storedMessages: Message[] = [];
@@ -66,11 +74,72 @@ const removeSpecificJob = (message: Message) => {
   storedMessages.splice(storedMessages.findIndex((m) => m === message));
 };
 
+const freeflowHiring = "https://discord.gg/gTWTwZPDYT";
+const freeflowForHire = "https://vjlup8tch3g.typeform.com/to/T8w8qWzl";
+
+const hiringTest = /hiring/i;
+const isHiring = (content: string) => hiringTest.test(content);
+
+const forHireTest = /for ?hire/i;
+const isForHire = (content: string) => forHireTest.test(content);
+
 const jobModeration = async (bot: Client) => {
   const jobBoard = await bot.channels.fetch(CHANNELS.jobBoard);
   if (!jobBoard?.isText() || !(jobBoard instanceof TextChannel)) return;
 
   await loadJobs(bot, jobBoard);
+
+  bot.on("interactionCreate", (interaction) => {
+    if (
+      interaction.isMessageComponent() &&
+      interaction.customId === "freeflow-hiring"
+    ) {
+      if (
+        !(interaction.message.mentions as MessageMentions).users.has(
+          interaction.user.id,
+        )
+      ) {
+        modLog(`<@${interaction.user.id}> invited to Freeflow by hiring link`);
+      } else {
+        modLog(`<@${interaction.user.id}> directed to hire from Freeflow`);
+      }
+      interaction.reply({
+        content: "Join the Freeflow community and start hiring developers",
+        ephemeral: true,
+        components: [
+          new MessageActionRow().addComponents(
+            new MessageButton()
+              .setURL(freeflowHiring)
+              .setLabel("Apply")
+              .setStyle("LINK"),
+          ),
+        ],
+      });
+    }
+    if (
+      interaction.isMessageComponent() &&
+      interaction.customId === "freeflow-for-hire"
+    ) {
+      if (
+        !(interaction.message.mentions as MessageMentions).users.has(
+          interaction.user.id,
+        )
+      ) {
+        modLog(
+          `<@${interaction.user.id}> invited to Freeflow by for hire link`,
+        );
+        return interaction.reply({
+          ephemeral: true,
+          content: `For more information about Freeflow, visit their website: <https://freeflow.dev/> or apply to join: ${freeflowForHire}`,
+        });
+      }
+      modLog(`<@${interaction.user.id}> directed to apply to Freeflow`);
+      interaction.reply({
+        content: `Apply to join Freeflow to get started: ${freeflowForHire}`,
+        ephemeral: true,
+      });
+    }
+  });
 
   bot.on("messageCreate", async (message) => {
     if (
@@ -118,6 +187,41 @@ const jobModeration = async (bot: Client) => {
         });
       moderatedMessageIds.add(message.id);
       message.delete();
+      return;
+    }
+
+    const DELETE_DELAY = 90;
+    const bannedWords = /(nft|blockchain|crypto)/;
+    if (bannedWords.test(simplifyString(message.content))) {
+      moderatedMessageIds.add(message.id);
+      const [reply] = await Promise.all([
+        message.reply({
+          content: `Sorry! We don't allow blockchain or related cryptocurrency roles to be advertised in our community. We encourage you to contact our Freeflow, a talent network for the cryptocurrency industry. This message will be deleted in ${DELETE_DELAY} seconds.`,
+          components: (() => {
+            const hiring = isHiring(message.content);
+            const forHire = isForHire(message.content);
+            const hiringLink = new MessageActionRow().addComponents(
+              new MessageButton()
+                .setCustomId("freeflow-hiring")
+                .setLabel("Start hiring")
+                .setStyle("PRIMARY"),
+            );
+            const forHireLink = new MessageActionRow().addComponents(
+              new MessageButton()
+                .setCustomId("freeflow-for-hire")
+                .setLabel("Request a Freeflow application")
+                .setStyle("PRIMARY"),
+            );
+            if (!hiring && !forHire) {
+              return [hiringLink, forHireLink];
+            }
+            return hiring ? [hiringLink] : [forHireLink];
+          })(),
+        }),
+        reportUser({ reason: ReportReasons.jobCrypto, message }),
+      ]);
+      await Promise.all([message.delete(), sleep(DELETE_DELAY)]);
+      await reply.delete();
       return;
     }
 

--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -209,12 +209,6 @@ const jobModeration = async (bot: Client) => {
     // Last, update the list of tracked messages.
     updateJobs(message);
   });
-  const modLog = bot.channels.cache.find(
-    (channel) => channel.id === CHANNELS.modLog,
-  );
-  if (!modLog?.isText()) {
-    throw new Error("Couldn't find #mod-log");
-  }
   bot.on("messageDelete", async (message) => {
     // TODO: look up audit log, early return if member was banned
     if (

--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -191,7 +191,7 @@ const jobModeration = async (bot: Client) => {
     }
 
     const DELETE_DELAY = 90;
-    const bannedWords = /(nft|blockchain|crypto)/;
+    const bannedWords = /(blockchain|nft|cryptocurrency|token|web3)/;
     if (bannedWords.test(simplifyString(message.content))) {
       moderatedMessageIds.add(message.id);
       const [reply] = await Promise.all([

--- a/src/helpers/modLog.ts
+++ b/src/helpers/modLog.ts
@@ -1,4 +1,9 @@
-import { GuildMember, Message } from "discord.js";
+import {
+  GuildMember,
+  Message,
+  MessageOptions,
+  MessagePayload,
+} from "discord.js";
 import { modRoleId } from "../constants";
 import {
   constructDiscordLink,
@@ -7,6 +12,13 @@ import {
 } from "./discord";
 import { simplifyString } from "../helpers/string";
 import { CHANNELS, getChannel } from "../constants/channels";
+
+export const modLog = async (
+  message: string | MessagePayload | MessageOptions,
+) => {
+  const logChannel = await getChannel(CHANNELS.jobsLog);
+  return await logChannel.send(message);
+};
 
 const warningMessages = new Map<
   string,
@@ -22,6 +34,7 @@ export const enum ReportReasons {
   jobAge = "jobAge",
   jobFrequency = "jobFrequency",
   jobRemoved = "jobRemoved",
+  jobCrypto = "jobCrypto",
 }
 
 interface Report {
@@ -169,6 +182,10 @@ ${reportedMessage}
     case ReportReasons.jobRemoved:
       return `${preface}, post was deleted:
 ${extra}
+${reportedMessage}
+`;
+    case ReportReasons.jobCrypto:
+      return `<@${message.author.id}> posted a crypto job:
 ${reportedMessage}
 `;
   }


### PR DESCRIPTION
Cryptocurrency and blockchain isn't the main focus of the community, and we've had a lot of issues with moderating job postings from members who want to share from these topics. [Freeflow](https://freeflow.dev) reached out to suggest that we refer these posters over to them, which is a great win/win — we can automatically remove all these posters, and the posters get a high-quality channel where they can promote themselves.

There are separate paths for employers and developers, which we attempt to infer automatically from the tags they use. If no tags were used, then we offer both paths.

User flow:

* Member posts with a trigger word (blockchain, nft, cryptocurrency, token, web3)
* Post is removed, and a reply sent with a button
* Upon button click, log privately the member and send a final link to Freeflow

Link buttons don't emit an interaction, and it's a requirement for us to have a log of who we sent their way for attribution reason. The double button isn't ideal, but there isn't another way to accomplish logging of who we refer.

<img width="592" alt="Screen Shot 2022-07-13 at 2 11 16 PM" src="https://user-images.githubusercontent.com/1551487/178829715-e386884a-eeac-47d7-970e-4af6e713d340.png">
<img width="587" alt="Screen Shot 2022-07-13 at 2 11 28 PM" src="https://user-images.githubusercontent.com/1551487/178829716-ddfbbc4c-3af5-42be-978c-c853455e38e1.png">
<img width="592" alt="Screen Shot 2022-07-13 at 2 11 37 PM" src="https://user-images.githubusercontent.com/1551487/178829718-4eb087c6-abac-4401-93d9-b80dbdcd3409.png">

