### PR TITLE
Optionally ping user within bot command's message

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -16,8 +16,12 @@ const prepareOptionalPingForward = ({ users, roles, repliedUser }: MessageMentio
     pingedReceivers.unshift(formatReceiverID(repliedUser.id));
   }
 
+  if (!pingedReceivers.length) {
+    return {};
+  }
+
   return {
-    content: `Hey ${pingedReceivers.join(', ')}! :wave: Please check the hint below. :point_down:`
+    content: `Hey ${pingedReceivers.join(', ')}! :wave: Please check the hint below. :point_down: \n\u200B`
   };
 }
 

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -1,11 +1,25 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import fetch from "node-fetch";
-import { Client, Message, TextChannel } from "discord.js";
+import { Client, Message, TextChannel, MessageMentions } from "discord.js";
 import cooldown from "./cooldown";
 import { ChannelHandlers } from "../types";
 import { isStaff } from "../helpers/discord";
 
 import * as report from "../commands/report";
+
+const prepareOptionalPingForward = ({ users, roles, repliedUser }: MessageMentions) => {
+  const formatReceiverID = (receiverID: string) => `<@${receiverID}>`;
+  const pingedReceiversIDs = [...users.keys(), ...roles.keys()];
+  const pingedReceivers = pingedReceiversIDs.map(formatReceiverID);
+  
+  if (repliedUser?.id) {
+    pingedReceivers.unshift(formatReceiverID(repliedUser.id));
+  }
+
+  return {
+    content: `Hey ${pingedReceivers.join(', ')}! :wave: Please check the hint below. :point_down:`
+  };
+}
 
 export const setupInteractions = (bot: Client) => {
   bot.on("interactionCreate", (interaction) => {
@@ -264,6 +278,7 @@ https://beta.reactjs.org/learn/sharing-state-between-components`,
     category: "Reactiflux",
     handleMessage: (msg) => {
       msg.channel.send({
+        ...prepareOptionalPingForward(msg.mentions),
         embeds: [
           {
             title: "Asking to ask",
@@ -296,6 +311,7 @@ How To Ask Questions The Smart Way https://git.io/JKscV
     category: "Reactiflux",
     handleMessage: (msg) => {
       msg.channel.send({
+        ...prepareOptionalPingForward(msg.mentions),
         embeds: [
           {
             title: "Attaching Code",
@@ -322,6 +338,7 @@ Link a Snack to share React Native examples: https://snack.expo.io
     category: "Reactiflux",
     handleMessage: (msg) => {
       msg.channel.send({
+        ...prepareOptionalPingForward(msg.mentions),
         embeds: [
           {
             title: "Don’t ping or DM other devs you aren’t actively talking to",


### PR DESCRIPTION
Hey, i noticed that it's a bit inconvenient that often people have to ping a folk, which they just notified about some hint (like how to properly attach a code or how to properly ask a question) via the bot - so first message is calling the bot with i.e. `!code` command and, after the bot replies, one has to add like "hey @ScriptyChris please take a look :point_up: " to actually notify other person about the given hint. So i prepared an enhancement that if a certain command is used with pings added and/or it's a reply, then bot will automatically forward these pings in a form of prefixed message to the response command.

Currently (for starters) the feature is hooked up with commands: `!ask`, `!code (!gist)`, `!ping`.
Looking forward for a feedback. :+1: 

I hope that below screens present the change more readably than my description. :)

**Before:**

![image](https://user-images.githubusercontent.com/18393526/180843879-99b9cf81-c871-4301-90d5-003f74e8f8d2.png)

**After:**

![image](https://user-images.githubusercontent.com/18393526/180844131-d3f71c00-e41b-486a-887a-45793aef9781.png)
![image](https://user-images.githubusercontent.com/18393526/180844674-07d80171-2159-44c6-a57d-15909ebb164b.png)