### PR TITLE
Updating the mdn url to match the new api structure to fix the mdn bot

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -388,7 +388,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
       const [fetchMsg, res] = await Promise.all([
         msg.channel.send(`Fetching "${query}"...`),
         fetch(
-          `https://developer.mozilla.org/api/v1/search/en-US?highlight=false&q=${query}`,
+          `https://developer.mozilla.org/api/v1/search?highlight=false&locale=en-us&q=${query}`,
         ),
       ]);
 


### PR DESCRIPTION
MDN  have changed the structure of their api, moving the locale from being a url parameter to being a query parameter.
Have tested on private server with reactibot