### PR TITLE
fix: remove link due to change in domain ownership

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -790,7 +790,6 @@ https://hnhiring.com/
 https://whoishiring.io/
 https://weworkremotely.com/
 https://remoteok.io/
-https://remote.com/
 https://remotive.io/remote-jobs/software-dev
             `,
             color: EMBED_COLOR,


### PR DESCRIPTION
## Overview

One of the links in the `!remote` command has had a change in ownership since the time it had been pinned in Reactiflux originally. This PR removes that bad link.

Apologies for not realizing sooner.