### PR TITLE
Feature/#259: Prepend message to suggest against code screenshots to the `!code` command output

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -296,7 +296,10 @@ How To Ask Questions The Smart Way https://git.io/JKscV
           {
             title: "Attaching Code",
             type: "rich",
-            description: `\\\`\\\`\\\`js
+            description: `
+Please don't post code in screenshots. Instead, use one of these:
+
+\\\`\\\`\\\`js
 // short code snippets go here
 \\\`\\\`\\\`
 


### PR DESCRIPTION
PR for #259

This pull request prepends "Please don't post code in screenshots. Instead, use one of these:" to the `!code` command output to suggest against posting screenshots of code.

### Changes

- Update `!code` command output.

### Notes

- I've altered the formatting of the command description slightly to start the content of the message on a new line to aid readability, in my opinion. Please let me know if this isn't preferred.

### Screenshots

![image](https://user-images.githubusercontent.com/35606709/197604000-3c6d98f1-4da9-4932-8272-8ed326082057.png)
