### PR TITLE
Feature/#262: Add command to explain the importance of keys when rendering lists in React

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -847,7 +847,9 @@ https://remotive.io/remote-jobs/software-dev
             title: "The importance of keys when rendering lists in React",
             type: "rich",
             description: `
-React depends on the use of stable and unique keys to identify items in a list so that it can perform correct and performant DOM updates. Keys are particularly important if the list can change over time.
+React depends on the use of stable and unique keys to identify items in a list so that it can perform correct and performant DOM updates. 
+
+Keys are particularly important if the list can change over time. React will use the index in the array by default if no key is specified. You can use the index in the array if the list doesn't change and you don't have a stable and unique key available. 
 
 Please see these resources for more information:
 

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -836,6 +836,30 @@ https://remotive.io/remote-jobs/software-dev
       });
     },
   },
+  {
+    words: [`!keys`],
+    help: `Explains the importance of keys when rendering lists in React`,
+    category: "React/Redux",
+    handleMessage: (msg) => {
+      msg.channel.send({
+        embeds: [
+          {
+            title: "The importance of keys when rendering lists in React",
+            type: "rich",
+            description: `
+React depends on the use of stable and unique keys to identify items in a list so that it can perform correct and performant DOM updates. Keys are particularly important if the list can change over time.
+
+Please see these resources for more information:
+
+https://beta.reactjs.org/learn/rendering-lists#keeping-list-items-in-order-with-key
+https://kentcdodds.com/blog/understanding-reacts-key-prop
+          `,
+            color: EMBED_COLOR,
+          },
+        ],
+      });
+    },
+  },
 ];
 
 const createCommandsMessage = () => {


### PR DESCRIPTION
PR for #262

This pull request adds a `!keys` command that explains the importance of keys when rendering lists in React. It also references two authoritative resources with further information.

### Changes

- Add `!keys` command.

### Screenshots

![image](https://user-images.githubusercontent.com/35606709/199104097-d2c2c7ea-44b6-4131-abf9-1f2f61e3155f.png)