### PR TITLE
chore(commands): update state update command links

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -180,7 +180,7 @@ console.log(state);
 where \`state\` is not the most up to date value when you log it. This is caused by state updates being asynchronous.
 
 Check out these resources for more information:
-https://gist.github.com/bpas247/e177a772b293025e5324219d231cf32c
+https://beta.reactjs.org/learn/queueing-a-series-of-state-updates
 https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous
 https://blog.isquaredsoftware.com/2020/05/blogged-answers-a-mostly-complete-guide-to-react-rendering-behavior/#render-batching-and-timing`,
             color: EMBED_COLOR,


### PR DESCRIPTION
Removes a link to an old post to be updated with a more reliable source (old post will most likely be deleted soon).