### PR TITLE
Feature/#271: Write low effort question remover feature

### DIFF
--- a/src/features/autothread.ts
+++ b/src/features/autothread.ts
@@ -10,6 +10,7 @@ import {
 import { sleep } from "../helpers/misc";
 import { ChannelHandlers } from "../types";
 import { threadStats } from "../features/stats";
+import { createNewThreadName } from "../helpers/threads";
 
 const CHECKS = ["☑️", "✔️", "✅"];
 const IDLE_TIMEOUT = 12;
@@ -39,7 +40,7 @@ const autoThread: ChannelHandlers = {
     }
     // Create threads
     const newThread = await msg.startThread({
-      name: `${msg.author.username} – ${format(new Date(), "HH-mm MMM d")}`,
+      name: createNewThreadName({ username: msg.author.username }),
     });
     threadStats.threadCreated(msg.channelId);
     // Send short-lived instructions

--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -5,6 +5,8 @@ import { ReportReasons, reportUser } from "../helpers/modLog";
 import { fetchReactionMembers, isHelpful, isStaff } from "../helpers/discord";
 import { partition } from "../helpers/array";
 import { sleep } from "../helpers/misc";
+import { EMBED_COLOR } from "./commands";
+import { createNewThreadName } from "../helpers/threads";
 
 const config = {
   // This is how many ️️warning reactions a post must get until it's considered an official warning
@@ -83,9 +85,28 @@ export const reactionHandlers: ReactionHandlers = {
       return;
     }
 
-    await message.delete();
+    const newThread = await message.startThread({
+      name: createNewThreadName({ username: message.author.username }),
+    });
 
-    await message.author.send("...");
+    await newThread.send({
+      embeds: [
+        {
+          title: "Please improve your question",
+          type: "rich",
+          description: `
+            Sorry, our most active helpers have flagged this as a question that needs more work before a good answer can be given. This may be because it's ambiguous, too broad, or otherwise challenging to answer. 
+
+            This is a good resource about asking good programming questions: 
+
+            https://zellwk.com/blog/asking-questions/
+          `,
+          color: EMBED_COLOR,
+        },
+      ],
+    });
+
+    await message.delete();
   },
 };
 

--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -119,8 +119,8 @@ https://zellwk.com/blog/asking-questions/
     reportUser({
       reason: ReportReasons.lowEffortQuestionRemoved,
       message,
-      staff: unknownReactors,
-      members: knownReactors,
+      staff: knownReactors,
+      members: unknownReactors,
     });
   },
 };

--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -2,7 +2,7 @@ import { MessageReaction, Message, GuildMember, Guild } from "discord.js";
 import cooldown from "./cooldown";
 import { ChannelHandlers } from "../types";
 import { ReportReasons, reportUser } from "../helpers/modLog";
-import { fetchReactionMembers, isStaff } from "../helpers/discord";
+import { fetchReactionMembers, isHelpful, isStaff } from "../helpers/discord";
 import { partition } from "../helpers/array";
 import { sleep } from "../helpers/misc";
 
@@ -68,6 +68,24 @@ export const reactionHandlers: ReactionHandlers = {
     }
 
     reportUser({ reason, message, staff, members });
+  },
+  "🔍": async ({ message, usersWhoReacted }) => {
+    const NUMBER_OF_REACTIONS_REQUIRED_FOR_DELETION = 2;
+
+    const hasRequiredNumberOfReactions =
+      usersWhoReacted.length >= NUMBER_OF_REACTIONS_REQUIRED_FOR_DELETION;
+
+    const hasAuthoritativeUserReacted = usersWhoReacted.some(
+      (userWhoReacted) => isStaff(userWhoReacted) || isHelpful(userWhoReacted),
+    );
+
+    if (!hasRequiredNumberOfReactions || !hasAuthoritativeUserReacted) {
+      return;
+    }
+
+    await message.delete();
+
+    await message.author.send("...");
   },
 };
 

--- a/src/helpers/modLog.ts
+++ b/src/helpers/modLog.ts
@@ -32,6 +32,7 @@ export const enum ReportReasons {
   jobFrequency = "jobFrequency",
   jobRemoved = "jobRemoved",
   jobCrypto = "jobCrypto",
+  lowEffortQuestionRemoved = "lowEffortQuestionRemoved",
 }
 
 interface Report {
@@ -112,18 +113,24 @@ const constructLog = ({
   const modAlert = `<@${modRoleId}>`;
   const preface = `<@${message.author.id}> in <#${message.channel.id}> warned 1 times`;
   const extra = origExtra ? `${origExtra}\n` : "";
+
+  const formattedUsersWhoReacted = members.length
+    ? `Reactors: ${members.map(({ user }) => user.username).join(", ")}\n`
+    : "";
+
+  const formattedStaffWhoReacted = staff.length
+    ? `Staff: ${staff.map(({ user }) => user.username).join(", ")}`
+    : "";
+
+  const usersWhoReacted = `${formattedUsersWhoReacted}
+${formattedStaffWhoReacted}
+`;
+
   const postfix = `Link: ${constructDiscordLink(message)}
 
-${
-  members.length
-    ? `Reactors: ${members.map(({ user }) => user.username).join(", ")}\n`
-    : ""
-}${
-    staff.length
-      ? `Staff: ${staff.map(({ user }) => user.username).join(", ")}`
-      : ""
-  }
+${usersWhoReacted}
 `;
+
   const reportedMessage = truncateMessage(
     escapeDisruptiveContent(quoteMessageContent(message.content)),
   );
@@ -163,6 +170,13 @@ ${reportedMessage}
     case ReportReasons.jobCrypto:
       return `<@${message.author.id}> posted a crypto job:
 ${reportedMessage}
+`;
+    case ReportReasons.lowEffortQuestionRemoved:
+      return `
+<@${message.author.id}> posted a low effort question in <#${message.channel.id}> that was removed: 
+
+${reportedMessage}
+${usersWhoReacted}
 `;
   }
 };

--- a/src/helpers/threads.ts
+++ b/src/helpers/threads.ts
@@ -1,0 +1,15 @@
+import { format } from "date-fns";
+
+interface CreateNewThreadNameParameters {
+  username: string;
+}
+
+export const createNewThreadName = ({
+  username,
+}: CreateNewThreadNameParameters) => {
+  const formattedDate = format(new Date(), "HH-mm MMM d");
+
+  const newThreadName = `${username} – ${formattedDate}`;
+
+  return newThreadName;
+};


### PR DESCRIPTION
PR for #271 

This pull request implements the bot feature that removes low-effort questions, educates the authors, and encourages them to ask more reasonable questions.

The feature:

- Creates a new thread from the offending message.
- Sends an educative and encouraging message to the thread to help the user improve their question (thanks @vcarl!).
- Deletes the offending message to clean up the channel.
- Logs the deletion in the moderation log.

### Changes

- Create and consume a shared utility function to create new thread names (I did this before changing the thread name/format subsequently but decided to leave it in).
- Extend the emoji moderation feature to include a reaction handler for low-effort questions.
- Extend the report log to support low-effort question removal logs.

### Notes

- ~I'm leaving the blurb up for debate. What message do we want to send to the author of the message?~
- I felt like it was sensible to extend the emoji moderation feature as essentially this is a form of emoji moderation, although I'm happy to separate this out should anyone strongly disagree. 
- I co-located the constants/configuration for this feature with the handler as it seemed sensible. Let me know if you disagree and would prefer it lifted up to module scope. 
- This introduces some conflation between helpers and staff in the moderation log as we're considering helpers to be authoritative here so that they can "approve" a message to be deleted. This means it will include helpers in the staff list in the report in the moderation log. I didn't think it was worth making the changes to make this distinction clearer but let me know if you disagree.
- To clarify behaviour, this expects at least one helpful or staff member to react _and_ at least two total reactions (so one helper, one member/one staff, one member/one staff one helper) to trigger.
