### PR TITLE
Feature/#271: Temporarily disable low-effort question remover feature

### DIFF
--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -71,6 +71,8 @@ export const reactionHandlers: ReactionHandlers = {
     reportUser({ reason, message, staff, members });
   },
   "🔍": async ({ message, usersWhoReacted }) => {
+    return; // Temporarily disable feature.
+
     const KNOWN_REACTOR_THRESHOLD = 1;
     const UNKNOWN_REACTOR_THRESHOLD = 2;
 


### PR DESCRIPTION
PR for #271 

This pull request temporarily disables the low-effort question remover feature whilst we clarify and update the deletion validation logic.