### PR TITLE
Quick adjustments to job moderation

### DIFF
--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -71,6 +71,7 @@ const ValidationMessages = {
     "Your message has multiple job postings, but the types are inconsistent. Please only post FOR HIRE or HIRING posts.",
   [POST_FAILURE_REASONS.tooManyEmojis]: "Your post has too many emojis.",
   [POST_FAILURE_REASONS.tooLong]: "Your post is too long.",
+  [POST_FAILURE_REASONS.tooManyLines]: "Your post has too many lines.",
   [POST_FAILURE_REASONS.tooManyGaps]:
     "Your post has too many spaces between lines. Make sure it’s either single spaced or double spaced.",
   [POST_FAILURE_REASONS.tooFrequent]: "You’re posting too frequently. ",
@@ -102,7 +103,8 @@ const jobModeration = async (bot: Client) => {
     }
     if (
       message.channelId !== CHANNELS.jobBoard ||
-      channel.type !== ChannelType.GuildText
+      channel.type !== ChannelType.GuildText ||
+      isStaff(message.member)
     ) {
       return;
     }

--- a/src/features/jobs-moderation/job-mod-helpers.ts
+++ b/src/features/jobs-moderation/job-mod-helpers.ts
@@ -22,6 +22,7 @@ export const enum POST_FAILURE_REASONS {
   inconsistentType = "inconsistentType",
   tooManyEmojis = "tooManyEmojis",
   tooLong = "tooLong",
+  tooManyLines = "tooManyLines",
   tooManyGaps = "tooManyGaps",
   tooFrequent = "tooFrequent",
   replyOrMention = "replyOrMention",
@@ -40,6 +41,9 @@ export interface PostFailureInconsistentType {
 }
 export interface PostFailureTooManyEmojis {
   type: POST_FAILURE_REASONS.tooManyEmojis;
+}
+export interface PostFailureTooManyLines {
+  type: POST_FAILURE_REASONS.tooManyLines;
 }
 export interface PostFailureTooLong {
   type: POST_FAILURE_REASONS.tooLong;
@@ -72,6 +76,7 @@ export type PostFailures =
   | PostFailureTooFrequent
   | PostFailureReplyOrMention
   | PostFailureTooLong
+  | PostFailureTooManyLines
   | PostFailureTooManyGaps
   | PostFailureTooManyEmojis
   | PostFailureWeb3Content

--- a/src/features/jobs-moderation/validate.ts
+++ b/src/features/jobs-moderation/validate.ts
@@ -57,10 +57,10 @@ export const formatting: JobPostValidator = (posts, message) => {
     }
     const messageLineCount = message.content.match(NEWLINE)?.length || 0;
     const lineCount = post.description.match(NEWLINE)?.length || 0;
-    if (
-      lineCount >
-      (isForHire ? 5 : 18 || post.description.length > (isForHire ? 300 : 1500))
-    ) {
+    if (lineCount > (isForHire ? 8 : 18)) {
+      errors.push({ type: POST_FAILURE_REASONS.tooManyLines });
+    }
+    if (post.description.length > (isForHire ? 350 : 1800)) {
       errors.push({ type: POST_FAILURE_REASONS.tooLong });
     }
     if (messageLineCount - 2 > lineCount) {

--- a/src/helpers/string.test.ts
+++ b/src/helpers/string.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { extractEmoji } from "./string";
+
+describe("extractEmoji", () => {
+  it("matches regular emoji", () => {
+    expect(extractEmoji("😄🙂👀🚀")).toEqual(["😄", "🙂", "👀", "🚀"]);
+    expect(extractEmoji("🤷🌟📚")).toEqual(["🤷", "🌟", "📚"]);
+    expect(extractEmoji("🐇🍈💕❤️")).toEqual(["🐇", "🍈", "💕", "❤"]);
+    // Because of limitaitons of compound emoji, this is close enough
+    expect(extractEmoji("👩‍👩‍👦‍👦")).toEqual(["👩", "👩", "👦", "👦"]);
+    expect(extractEmoji("👩‍❤️‍👩")).toEqual(["👩", "❤", "👩"]);
+  });
+  it("matches unusual unicode characters", () => {
+    expect(extractEmoji("♌☄⚥")).toEqual(["♌", "☄", "⚥"]);
+    expect(extractEmoji("┠╿╋╂")).toEqual(["┠", "╿", "╋", "╂"]);
+  });
+  it("doesn’t match international characters", () => {
+    expect(extractEmoji("מחרוזת בדיקה ומה לא")).toEqual([]);
+    expect(extractEmoji("Тестовий рядок і таке інше")).toEqual([]);
+    expect(extractEmoji("テスト文字列など")).toEqual([]);
+    expect(extractEmoji("测试字符串等等")).toEqual([]);
+    expect(extractEmoji("테스트 문자열 및 기타")).toEqual([]);
+    expect(extractEmoji("Chuỗi kiểm tra và không có gì")).toEqual([]);
+  });
+  it("doesn’t match funky invisible Unicode characters", () => {
+    // eslint-disable-next-line no-irregular-whitespace
+    expect(extractEmoji(`    `)).toEqual([]);
+  });
+});

--- a/src/helpers/string.ts
+++ b/src/helpers/string.ts
@@ -1,8 +1,9 @@
 const NORMALIZED_CODEPOINTS = /[\u0300-\u036f]/g;
 const EMOJI_RANGE =
-  /[\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF]/g;
+  /[\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2500-\u26FF]|\uD83E[\uDD10-\uDDFF]/g;
 const SPECIAL_CHARACTERS =
-  /[≤≥¯˘÷¿…“”‘’«»–—≠±ºª•¶§∞¢£™¡`~`∑´®†¨ˆØ∏\-=_<>,;'"[\]\\{}|!@#$%^*()]/g;
+  // eslint-disable-next-line no-control-regex
+  /[\u0000-\u001F]|[\u2000-\u24FF]|[≤≥¯˘÷¿…“”‘’«»–—≠±ºª•¶§∞¢£™¡`~`∑´®†¨ˆØ∏\-=_<>,;'"[\]\\{}|!@#$%^*()]/g;
 export const simplifyString = (s: string) =>
   s
     .toLowerCase()


### PR DESCRIPTION
* Fix some control characters being interpreted as emoji
* Improve error message when there are too many newlines
* Loosen length restrictions on FORHIRE posts
* Don't run typical validation against staff accounts