### PR TITLE
Job board – Hotfix some high priority fixes

### DIFF
--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -110,7 +110,11 @@ const jobModeration = async (bot: Client) => {
 
   bot.on("messageCreate", async (message) => {
     const { channel } = message;
-    if (message.author.bot) {
+    if (
+      message.author.bot ||
+      // Don't treat newly fetched old messages as new posts
+      differenceInHours(new Date(), message.createdAt) < 1
+    ) {
       return;
     }
     // If this is an existing enforcement thread, process the through a "REPL"

--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -268,7 +268,17 @@ ${errors.map((e) => `- ${getValidationMessage(e)}`).join("\n")}`,
     await thread.send(
       `Hey <@${
         message.author.id
-      }>, your message does not meet our requirements to be posted to the board. This thread acts as a REPL where you can test out new posts against our validation rules.
+      }>, your message does not meet our requirements to be posted to the board. This thread acts as a REPL where you can test out new posts against our validation rules. Here's an example of a valid post:
+
+> HIRING | REMOTE | FULL-TIME
+> 
+> Senior React Engineer: $min - $max
+> 
+> Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+> 
+> More details & apply: https://example.com/apply
+      
+You can view our guidance for job posts here: <https://www.reactiflux.com/promotion#job-board>.
     
 It was removed for these reasons:
 

--- a/src/features/jobs-moderation/job-mod-helpers.ts
+++ b/src/features/jobs-moderation/job-mod-helpers.ts
@@ -126,7 +126,7 @@ export const loadJobs = async (bot: Client, channel: TextChannel) => {
 };
 
 const POST_INTERVAL = 7;
-const FORHIRE_AGE_LIMIT = 1.25;
+const FORHIRE_AGE_LIMIT = 1.25 * 24;
 
 export const deleteAgedPosts = async () => {
   // Delete all `forhire` messages that are older than the age limit

--- a/src/features/jobs-moderation/job-mod-helpers.ts
+++ b/src/features/jobs-moderation/job-mod-helpers.ts
@@ -146,10 +146,10 @@ export const deleteAgedPosts = async () => {
   );
   while (
     forHirePosts[0] &&
-    differenceInHours(new Date(), jobBoardMessageCache[0].createdAt) >=
+    differenceInHours(new Date(), forHirePosts[0].createdAt) >=
       FORHIRE_AGE_LIMIT
   ) {
-    const { message } = jobBoardMessageCache[0];
+    const { message } = forHirePosts[0];
     await message.fetch();
     if (!message.deletable) {
       console.log(


### PR DESCRIPTION
Found 2 critical bugs:

- `deleteAgedPosts` was incorrectly operating on the full list of posts, not just `forhire` posts
- The interval was incorrectly set at 1.25 hours, not 1.25 days.

This also should fix a bug where `message.fetch()` on old messages that aren't in the message cache are emitting `messageCreate` events (I think? It's not documented anywhere)