### PR TITLE
One more job board patch

### DIFF
--- a/src/features/jobs-moderation/job-mod-helpers.ts
+++ b/src/features/jobs-moderation/job-mod-helpers.ts
@@ -175,6 +175,13 @@ export const deleteAgedPosts = async () => {
         message,
         extra: `Originally sent ${format(new Date(message.createdAt), "P p")}`,
       });
+      await message.delete();
+      jobBoardMessageCache.shift();
+      console.log(
+        `[INFO]: deleteAgedPosts() deleted post ${constructDiscordLink(
+          message,
+        )}`,
+      );
     } catch (e) {
       logger.log(
         "[DEBUG]",
@@ -183,11 +190,6 @@ export const deleteAgedPosts = async () => {
         )}' not found`,
       );
     }
-    await message.delete();
-    jobBoardMessageCache.shift();
-    console.log(
-      `[INFO]: deleteAgedPosts() deleted post ${constructDiscordLink(message)}`,
-    );
   }
 };
 

--- a/src/features/jobs-moderation/job-mod-helpers.ts
+++ b/src/features/jobs-moderation/job-mod-helpers.ts
@@ -187,8 +187,11 @@ export const deleteAgedPosts = async () => {
         "[DEBUG]",
         `deleteAgedPosts() message '${constructDiscordLink(
           message,
-        )}' not found`,
+        )}' not found, originally sent by ${
+          message.author.username
+        } at ${format(message.createdAt, "P p")}`,
       );
+      jobBoardMessageCache.shift();
     }
   }
 };


### PR DESCRIPTION
I'm growing suspicious that we may have been flagged by Discord's systems for quirky bot behavior, trying to fetch/delete old messages (or something). Testing locally and this still works same as ever, so either there's something specific about the real server's job board, or something quirky with the application ID in Discord's systems. But anyway this is def a bug