### PR TITLE
Update metrics: track forum post tags, message channel category

### DIFF
--- a/src/features/stats.ts
+++ b/src/features/stats.ts
@@ -79,16 +79,25 @@ const stats = (client: Client) => {
   client.on("messageCreate", async (msg) => {
     const { member, author, channel, content } = msg;
 
-    if (!channel || !author || author.bot || msg.system) return;
-
-    const channelId =
+    if (
+      !channel ||
+      !channel.isTextBased() ||
+      channel.isDMBased() ||
+      !author ||
+      author.bot ||
+      msg.system
+    ) {
+      return;
+    }
+    const rootChannel =
       channel.isThread() && channel.parent
-        ? (await channel.parent.fetch()).id
-        : channel.id;
+        ? await channel.parent.fetch()
+        : channel;
 
     emitEvent(message, {
       data: {
-        channel: channelId,
+        channel: rootChannel.id,
+        category: rootChannel.parentId ?? "0",
         messageLength: content?.length ?? 0,
         roles: member
           ? [...member.roles.cache.values()]

--- a/src/features/stats.ts
+++ b/src/features/stats.ts
@@ -1,7 +1,9 @@
 import fetch from "node-fetch";
 import queryString from "query-string";
-import { Client } from "discord.js";
+import { ChannelType, Client } from "discord.js";
 import { amplitudeKey } from "../helpers/env";
+import { difference } from "../helpers/sets";
+import { mapAppliedTagsToTagNames } from "../helpers/discord";
 
 type AmplitudeValue = string | number | boolean;
 type EmitEventData = Record<string, AmplitudeValue | AmplitudeValue[]>;
@@ -32,6 +34,7 @@ const emitEvent = (
 };
 
 const message = "message sent";
+const postTagged = "post tagged";
 const threadCreated = "thread created";
 const threadReplyRemoved = "thread reply removed";
 const threadTimeout = "thread timeout";
@@ -39,6 +42,8 @@ const threadResolved = "thread resolved";
 const reacted = "reaction added";
 
 export const threadStats = {
+  postTagged: (tags: string[], channel: string) =>
+    emitEvent(postTagged, { data: { tags, channel } }),
   threadCreated: (channel: string) =>
     emitEvent(threadCreated, { data: { channel } }),
   threadReplyRemoved: (channel: string) =>
@@ -57,6 +62,37 @@ export const threadStats = {
 };
 
 const stats = (client: Client) => {
+  client.on("threadUpdate", async (oldThread, newThread) => {
+    if (oldThread.parent?.type !== ChannelType.GuildForum) {
+      return;
+    }
+    const appliedTags = [
+      ...difference(
+        new Set(newThread.appliedTags),
+        new Set(oldThread.appliedTags),
+      ),
+    ];
+
+    if (appliedTags.length === 0) {
+      return;
+    }
+
+    threadStats.postTagged(
+      mapAppliedTagsToTagNames(appliedTags, oldThread.parent),
+      newThread.parentId ?? "0",
+    );
+  });
+  client.on("threadCreate", async (thread) => {
+    if (
+      thread.parent?.type === ChannelType.GuildForum &&
+      thread.appliedTags.length > 0
+    ) {
+      threadStats.postTagged(
+        mapAppliedTagsToTagNames(thread.appliedTags, thread.parent),
+        thread.parentId ?? "0",
+      );
+    }
+  });
   client.on("messageReactionAdd", async (reaction, user) => {
     const { message, emoji } = reaction;
     const { channel } = message;
@@ -72,6 +108,7 @@ const stats = (client: Client) => {
       data: {
         channel: channelId,
         emoji: emoji.toString() ?? "n/a",
+        target: message.author?.id ?? "0",
       },
       userId: user.id,
     });

--- a/src/helpers/discord.ts
+++ b/src/helpers/discord.ts
@@ -13,6 +13,7 @@ import {
   SlashCommandBuilder,
   APIApplicationCommand,
   APIApplicationCommandOption,
+  ForumChannel,
 } from "discord.js";
 import prettyBytes from "pretty-bytes";
 
@@ -111,6 +112,16 @@ export const escapeDisruptiveContent = (content: string) => {
 
 export const quoteAndEscape = (content: string) => {
   return escapeDisruptiveContent(quoteMessageContent(content));
+};
+
+export const mapAppliedTagsToTagNames = (
+  appliedTags: string[],
+  channel: ForumChannel,
+) => {
+  const { availableTags: tags } = channel;
+  const tagLookup = new Map(tags.map((e) => [e.id, e]));
+
+  return appliedTags.map((id) => tagLookup.get(id)?.name ?? "");
 };
 
 //

--- a/src/helpers/sets.ts
+++ b/src/helpers/sets.ts
@@ -1,2 +1,5 @@
+/**
+ * Difference returns a list of items that are in A but is not present in B.
+ */
 export const difference = <T>(a: Set<T>, b: Set<T>) =>
   new Set(Array.from(a).filter((x) => !b.has(x)));


### PR DESCRIPTION
The Star Helper admin work has shown me that we could more effectively use our metrics to drive activity-based segments of the community if we can segment activity by channel group, i.e. by asking for a chart of the top 25 posters by message volume in the "Need Help" channel category, vs pulling out individual channel IDs to build the same chart.

Similarly, we could use channel tags to monitor usage of different tags. Right now we don't make much use of forums, but we're exploring a change to help channels that would more strongly emphasize them.