### PR TITLE
update: !conduct command. Change the CoC link to a descriptive hyperlink

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -54,7 +54,7 @@ const commandsList: Command[] = [
           {
             title: "Code of Conduct",
             type: EmbedType.Rich,
-            description: `Reactiflux is the largest chat community of React developers. We make a deliberate effort to have a light touch when it comes to moderating, but we do have some expectations of how our members will behave. Please read the full Code of Conduct at https://www.reactiflux.com/conduct`,
+            description: `Reactiflux is the largest chat community of React developers. We make a deliberate effort to have a light touch when it comes to moderating, but we do have some expectations of how our members will behave. Please read the [full Reactiflux Code of Conduct](https://www.reactiflux.com/conduct)`,
             color: EMBED_COLOR,
           },
         ],


### PR DESCRIPTION
A small change to create a descriptive hyperlink in the output of this command. Both the current version and the updated version are shown below respectively. 

![Screenshot 2023-08-22 at 13 06 03](https://github.com/reactiflux/reactibot/assets/81025586/494f0282-c8f9-47b9-b6d3-fca9bcadfe3d)
