### PR TITLE
update !promotion command with a hyperlink

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -71,7 +71,7 @@ const commandsList: Command[] = [
           {
             title: "Self Promotion",
             type: EmbedType.Rich,
-            description: `Reactiflux is a peer group, not an advertising channel or a free audience. Please review our guidelines around self-promotion at https://www.reactiflux.com/promotion`,
+            description: `Reactiflux is a peer group, not an advertising channel or a free audience. Please review [our guidelines around self-promotion](https://www.reactiflux.com/promotion)`,
             color: EMBED_COLOR,
           },
         ],


### PR DESCRIPTION
A minor change to create a descriptive hyperlink in the output of this command `!promotion`. Both the current version and the updated version are shown below respectively.

![Screenshot 2023-08-22 at 13 10 55](https://github.com/reactiflux/reactibot/assets/81025586/62c4238a-e9ef-4683-8787-3a810e232a65)
