### PR TITLE
update !rrlinks link to descriptive hyperlink

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -88,7 +88,7 @@ const commandsList: Command[] = [
           {
             title: "Helpful links",
             type: EmbedType.Rich,
-            description: `Reactiflux's Mark Erikson has put together a curated list of useful React & Redux links for developers of all skill levels. Check out https://github.com/markerikson/react-redux-links`,
+            description: `Reactiflux's Mark Erikson has put together [a curated list of useful React & Redux links](https://github.com/markerikson/react-redux-links) for developers of all skill levels.`,
             color: EMBED_COLOR,
           },
         ],


### PR DESCRIPTION
A minor edit to include the link as a descriptive hyperlink

Both the current and PR version output are shown below respectively.

![Screenshot 2023-08-22 at 13 13 40](https://github.com/reactiflux/reactibot/assets/81025586/b064a5ce-2b10-4581-a3b5-9362009f7177)
