### PR TITLE
Job board line count, edit tracking, edited hiring posts. Low effort questions

### DIFF
--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -63,7 +63,7 @@ export const reactionHandlers: ReactionHandlers = {
     }
 
     const staffReactionCount = usersWhoReacted.filter(isStaff).length;
-    const [members, staff] = partition(isStaff, usersWhoReacted);
+    const [staff, members] = partition(isStaff, usersWhoReacted);
     const meetsDeletion = staffReactionCount >= config.deletionThreshold;
 
     if (meetsDeletion) {

--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -98,9 +98,12 @@ export const reactionHandlers: ReactionHandlers = {
           description: `
 Sorry, our most active helpers have flagged this as a question that needs more work before a good answer can be given. This may be because it's ambiguous, too broad, or otherwise challenging to answer. 
 
-This is a good resource about asking good programming questions: 
+Zell Liew [wrote a great resource](https://zellwk.com/blog/asking-questions/) about asking good programming questions.
 
-https://zellwk.com/blog/asking-questions/
+- The onus is on the asker to craft a question that is easy to answer.
+- A good question is specific, clear, concise, and shows effort on the part of the asker.
+- Share just the relevant parts of the code, using tools like Codepen, CodeSandbox, or GitHub for better clarity.
+- Making a question specific and to the point is a sign of respecting the responder’s time, which increases the likelihood of getting a good answer.
 
 (this was triggered by crossing a threshold of "🔍" reactions on the original message)
           `,

--- a/src/features/jobs-moderation.ts
+++ b/src/features/jobs-moderation.ts
@@ -164,6 +164,10 @@ const jobModeration = async (bot: Client) => {
     }
     const message = await newMessage.fetch();
     const posts = parseContent(message.content);
+    // Don't validate hiring posts
+    if (posts.every((p) => p.tags.includes(PostType.hiring))) {
+      return;
+    }
     // You can't post too frequently when editing a message, so filter those out
     const errors = validate(posts, message).filter(
       (e) => e.type !== POST_FAILURE_REASONS.tooFrequent,

--- a/src/features/jobs-moderation/job-mod-helpers.ts
+++ b/src/features/jobs-moderation/job-mod-helpers.ts
@@ -129,7 +129,7 @@ export const loadJobs = async (bot: Client, channel: TextChannel) => {
         !m.message.system &&
         m.authorId !== bot.user?.id,
     );
-    const [forHire, hiring] = partition(
+    const [hiring, forHire] = partition(
       (m) => m.type === PostType.hiring,
       humanMessages,
     );

--- a/src/features/jobs-moderation/validate.ts
+++ b/src/features/jobs-moderation/validate.ts
@@ -63,7 +63,7 @@ export const formatting: JobPostValidator = (posts, message) => {
     if (lineCount > maxLines) {
       errors.push({
         type: POST_FAILURE_REASONS.tooManyLines,
-        overage: lineCount - maxLines,
+        overage: maxLines - lineCount,
       });
     }
     const maxChars = isForHire ? 350 : 1800;

--- a/src/features/jobs-moderation/validate.ts
+++ b/src/features/jobs-moderation/validate.ts
@@ -3,7 +3,7 @@ import { differenceInHours } from "date-fns";
 
 import { getLastPostAge } from "./job-mod-helpers";
 
-import { simplifyString } from "../../helpers/string";
+import { countLines, simplifyString } from "../../helpers/string";
 import { extractEmoji } from "../../helpers/string";
 import { getCryptoCache, setCryptoCache } from "./job-mod-helpers";
 import { parseContent } from "./parse-content";
@@ -23,7 +23,6 @@ const validate = (posts: ReturnType<typeof parseContent>, message: Message) => {
 };
 export default validate;
 
-const NEWLINE = /\n/g;
 const GAP = /\n\s*\n\s*\n/g;
 export const formatting: JobPostValidator = (posts, message) => {
   // Handle missing tags;
@@ -59,7 +58,7 @@ export const formatting: JobPostValidator = (posts, message) => {
     if (emojiCount / post.description.length > 1 / 150) {
       errors.push({ type: POST_FAILURE_REASONS.tooManyEmojis });
     }
-    const lineCount = post.description.match(NEWLINE)?.length || 0;
+    const lineCount = countLines(post.description.trim());
     const maxLines = isForHire ? 8 : 18;
     if (lineCount > maxLines) {
       errors.push({

--- a/src/features/jobs-moderation/validation-messages.ts
+++ b/src/features/jobs-moderation/validation-messages.ts
@@ -27,7 +27,7 @@ const ValidationMessages = {
   [POST_FAILURE_REASONS.tooLong]: (e: PostFailureTooLong) =>
     `Your post is too long, please shorten it by ${e.overage} characters.`,
   [POST_FAILURE_REASONS.tooManyLines]: (e: PostFailureTooManyLines) =>
-    `Your post has too many, please shorten it by ${e.overage} lines.`,
+    `Your post has too many lines, please shorten it by ${e.overage} lines.`,
   [POST_FAILURE_REASONS.tooManyGaps]:
     "Your post has too many spaces between lines, please make sure it’s either single spaced or double spaced.",
   [POST_FAILURE_REASONS.tooFrequent]: (e: PostFailureTooFrequent) =>

--- a/src/helpers/array.test.ts
+++ b/src/helpers/array.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { partition } from "./array";
+
+describe("partition", () => {
+  it("matches regular emoji", () => {
+    expect(partition((x) => x > 4, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])).toEqual([
+      [5, 6, 7, 8, 9],
+      [0, 1, 2, 3, 4],
+    ]);
+  });
+});

--- a/src/helpers/array.ts
+++ b/src/helpers/array.ts
@@ -9,7 +9,7 @@
 export const partition = <Data>(predicate: (d: Data) => boolean, xs: Data[]) =>
   xs.reduce(
     (acc, cur) => {
-      acc[predicate(cur) ? 1 : 0].push(cur);
+      acc[predicate(cur) ? 0 : 1].push(cur);
       return acc;
     },
     [[], []] as [Data[], Data[]],

--- a/src/helpers/discord.ts
+++ b/src/helpers/discord.ts
@@ -14,6 +14,8 @@ import {
   APIApplicationCommand,
   APIApplicationCommandOption,
   ForumChannel,
+  ChannelType,
+  GuildTextThreadCreateOptions,
 } from "discord.js";
 import prettyBytes from "pretty-bytes";
 
@@ -61,6 +63,25 @@ export const fetchReactionMembers = (
   } catch (e) {
     return Promise.resolve([] as GuildMember[]);
   }
+};
+
+export const createPrivateThreadFromMessage = async (
+  msg: Message,
+  options: GuildTextThreadCreateOptions<ChannelType.PrivateThread>,
+) => {
+  options = { ...options, type: ChannelType.PrivateThread };
+  if (msg.channel.type === ChannelType.GuildText) {
+    return msg.channel.threads.create(options);
+  }
+  if (
+    msg.channel.type === ChannelType.PublicThread &&
+    msg.channel.parent?.type === ChannelType.GuildText
+  ) {
+    return msg.channel.parent.threads.create(options);
+  }
+  throw new Error(
+    `Could not create private thread from message. channel: ${msg.channel.id} type: ${msg.channel.type}`,
+  );
 };
 
 /*

--- a/src/helpers/modLog.ts
+++ b/src/helpers/modLog.ts
@@ -160,7 +160,9 @@ ${reportedMessage}
 `;
 
     case ReportReasons.jobCircumvent:
-      return `${preface}, tried to circumvent job board rules by editing their message. The message has been removed.`;
+      return `${preface}, tried to circumvent job board rules by editing their message. The message has been removed:
+
+${reportedMessage}`;
     case ReportReasons.jobAge:
       return `${preface}, for hire post expired.`;
     case ReportReasons.jobFrequency:

--- a/src/helpers/string.test.ts
+++ b/src/helpers/string.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractEmoji } from "./string";
+import { countLines, extractEmoji } from "./string";
 
 describe("extractEmoji", () => {
   it("matches regular emoji", () => {
@@ -25,5 +25,13 @@ describe("extractEmoji", () => {
   it("doesn’t match funky invisible Unicode characters", () => {
     // eslint-disable-next-line no-irregular-whitespace
     expect(extractEmoji(`    `)).toEqual([]);
+  });
+});
+
+describe("countLines", () => {
+  it("counts lines", () => {
+    expect(countLines("")).toEqual(0);
+    expect(countLines("\n\ntest\nstuff\n\n\n\n\nyo\nhello")).toEqual(9);
+    expect(countLines("\n\ntest\nstuff\n\n\n\n\nyo\nhello".trim())).toEqual(7);
   });
 });

--- a/src/helpers/string.ts
+++ b/src/helpers/string.ts
@@ -13,3 +13,6 @@ export const simplifyString = (s: string) =>
     .replace(SPECIAL_CHARACTERS, "");
 
 export const extractEmoji = (s: string) => s.match(EMOJI_RANGE) || [];
+
+const NEWLINE = /\n/g;
+export const countLines = (s: string) => s.match(NEWLINE)?.length || 0;


### PR DESCRIPTION
- #312 Don't re-validate `hiring` posts if they're edited, so they never get removed
- #313 Log pre- and post-edit messages, so we can spot-check for accidents or nefarious activity
- #314 Fix line count validation and typo
- #316 Change "low effort question" thread to be private
- Fixes a bug in `partition()` where documented behavior didn't match code