### PR TITLE
Implement search React documentation command #348

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -4,6 +4,7 @@ import { ChannelType, EmbedType, Message, TextChannel } from "discord.js";
 import cooldown from "./cooldown";
 import { ChannelHandlers } from "../types";
 import { isStaff } from "../helpers/discord";
+import { getReactDocsContent, getReactDocsSearchKey } from "../helpers/react-docs";
 
 export const EMBED_COLOR = 7506394;
 
@@ -159,19 +160,11 @@ Read more about this in the [article "You Might Not Need Redux" by Dan Abramov](
           {
             title: "State Updates May Be Asynchronous",
             type: EmbedType.Rich,
-            description: `Often times you run into an issue like this
-\`\`\`js
-const handleEvent = e => {
-setState(e.target.value);
-console.log(state);
-}
-\`\`\`
-where \`state\` is not the most up to date value when you log it. This is caused by state updates being asynchronous.
+            description: `\`useState\` is a React Hook that lets you add a [state variable](https://react.dev/learn/state-a-components-memory) to your component.
 
-Check out these resources for more information:
-- [React.dev: Queueing a Series of State Updates](https://react.dev/learn/queueing-a-series-of-state-updates)
-- [ReactJS.org: State Updates May Be Asynchronous](https://legacy.reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous)
-- [Blogged Answers: Render Batching and Timing](https://blog.isquaredsoftware.com/2020/05/blogged-answers-a-mostly-complete-guide-to-react-rendering-behavior/#render-batching-and-timing)`,
+\`\`\`js
+const [state, setState] = useState(initialState)
+\`\`\``,
             color: EMBED_COLOR,
           },
         ],
@@ -233,7 +226,7 @@ Check out [this article on "Why and how to bind methods in your React component 
           {
             title: "Lifting State Up",
             type: EmbedType.Rich,
-            description: `Often, several components need to reflect the same changing data. We recommend lifting the shared state up to their closest common ancestor. 
+            description: `Often, several components need to reflect the same changing data. We recommend lifting the shared state up to their closest common ancestor.
 
 Learn more about lifting state in the [React.dev article about "Sharing State Between Components"](https://react.dev/learn/sharing-state-between-components).`,
             color: EMBED_COLOR,
@@ -408,6 +401,53 @@ Here's an article explaining the difference between the two: https://goshakkk.na
             description,
             color: 0x83d0f2,
             url: `https://developer.mozilla.org${mdnUrl}`,
+          },
+        ],
+      });
+
+      fetchMsg.delete();
+    },
+  },
+  {
+    words: ["!react-docs", "!docs"],
+    help: "Allows you to search the React docs, usage: !docs useState",
+    category: "Web",
+    handleMessage: async (msg) => {
+      const [, search] = msg.content.split(" ");
+
+      const searchKey = getReactDocsSearchKey(search);
+
+      if (!searchKey) {
+        msg.channel.send(
+          `Could not find anything on React docs for '${search}'`,
+        );
+        return;
+      }
+
+      const [fetchMsg, content] = await Promise.all([
+        msg.channel.send(`Looking up documentation for "${search}"...`),
+        getReactDocsContent(searchKey),
+      ]);
+
+      if (!content) {
+        fetchMsg.edit(`Could not find anything on React docs for '${search}'`);
+        return;
+      }
+
+      await msg.channel.send({
+        embeds: [
+          {
+            title: `${searchKey}`,
+            type: EmbedType.Rich,
+            description: content,
+            color: EMBED_COLOR,
+            url: `https://react.dev/reference/${searchKey}`,
+            author: {
+              name: "React documentation",
+              icon_url:
+                "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1150px-React-icon.svg.png",
+              url: "https://react.dev/",
+            },
           },
         ],
       });
@@ -832,7 +872,7 @@ https://exploringjs.com/es6/ch_variables.html#_pitfall-const-does-not-make-the-v
             title: "Acquiring a remote position",
             type: EmbedType.Rich,
             description: `
-Below is a list of resources we commonly point to as an aid in a search for remote jobs. 
+Below is a list of resources we commonly point to as an aid in a search for remote jobs.
 
 NOTE: If you are looking for your first job in the field or are earlier in your career, then getting a remote job at this stage is incredibly rare. We recommend prioritizing getting a job local to the area you are in or possibly moving to an area for work if options are limited where you are.
 
@@ -882,9 +922,9 @@ Remote work has the most competition, and thus is likely to be more difficult to
             title: "The importance of keys when rendering lists in React",
             type: EmbedType.Rich,
             description: `
-React depends on the use of stable and unique keys to identify items in a list so that it can perform correct and performant DOM updates. 
+React depends on the use of stable and unique keys to identify items in a list so that it can perform correct and performant DOM updates.
 
-Keys are particularly important if the list can change over time. React will use the index in the array by default if no key is specified. You can use the index in the array if the list doesn't change and you don't have a stable and unique key available. 
+Keys are particularly important if the list can change over time. React will use the index in the array by default if no key is specified. You can use the index in the array if the list doesn't change and you don't have a stable and unique key available.
 
 Please see these resources for more information:
 
@@ -946,7 +986,7 @@ _ _
                 name: "Meta Frameworks",
                 value: `
 - [Next.js](https://nextjs.org/)
-- [Remix](https://remix.run/)                
+- [Remix](https://remix.run/)
 - [Astro](https://astro.build/)
 - [SvelteKit](https://kit.svelte.dev/)
 - [Nuxt](https://nuxtjs.org/)

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -406,7 +406,7 @@ Here's an article explaining the difference between the two: https://goshakkk.na
               name: "MDN",
               url: "https://developer.mozilla.org",
               icon_url:
-                "https://developer.mozilla.org/static/img/opengraph-logo.72382e605ce3.png",
+                "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
             },
             title,
             description,

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -1,10 +1,13 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import fetch from "node-fetch";
-import { ChannelType, EmbedType, Message, TextChannel } from "discord.js";
+import { APIEmbed, ChannelType, EmbedType, Message, MessageCreateOptions, MessagePayload, TextChannel } from "discord.js";
 import cooldown from "./cooldown";
 import { ChannelHandlers } from "../types";
 import { isStaff } from "../helpers/discord";
-import { getReactDocsContent, getReactDocsSearchKey } from "../helpers/react-docs";
+import {
+  getReactDocsContent,
+  getReactDocsSearchKey,
+} from "../helpers/react-docs";
 
 export const EMBED_COLOR = 7506394;
 
@@ -160,11 +163,19 @@ Read more about this in the [article "You Might Not Need Redux" by Dan Abramov](
           {
             title: "State Updates May Be Asynchronous",
             type: EmbedType.Rich,
-            description: `\`useState\` is a React Hook that lets you add a [state variable](https://react.dev/learn/state-a-components-memory) to your component.
-
+            description: `Often times you run into an issue like this
 \`\`\`js
-const [state, setState] = useState(initialState)
-\`\`\``,
+const handleEvent = e => {
+setState(e.target.value);
+console.log(state);
+}
+\`\`\`
+where \`state\` is not the most up to date value when you log it. This is caused by state updates being asynchronous.
+
+Check out these resources for more information:
+- [React.dev: Queueing a Series of State Updates](https://react.dev/learn/queueing-a-series-of-state-updates)
+- [ReactJS.org: State Updates May Be Asynchronous](https://legacy.reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous)
+- [Blogged Answers: Render Batching and Timing](https://blog.isquaredsoftware.com/2020/05/blogged-answers-a-mostly-complete-guide-to-react-rendering-behavior/#render-batching-and-timing)`,
             color: EMBED_COLOR,
           },
         ],
@@ -418,19 +429,21 @@ Here's an article explaining the difference between the two: https://goshakkk.na
       const searchKey = getReactDocsSearchKey(search);
 
       if (!searchKey) {
-        msg.channel.send(
-          `Could not find anything on React docs for '${search}'`,
-        );
+        msg.channel.send({
+          embeds: generateReactDocsErrorEmbeds(search),
+        });
         return;
       }
 
       const [fetchMsg, content] = await Promise.all([
-        msg.channel.send(`Looking up documentation for "${search}"...`),
+        msg.channel.send(`Looking up documentation for **'${search}'**...`),
         getReactDocsContent(searchKey),
       ]);
 
       if (!content) {
-        fetchMsg.edit(`Could not find anything on React docs for '${search}'`);
+        fetchMsg.edit({
+          embeds: generateReactDocsErrorEmbeds(search),
+        });
         return;
       }
 
@@ -1155,6 +1168,22 @@ const commands: ChannelHandlers = {
       }
     });
   },
+};
+
+const generateReactDocsErrorEmbeds = (search: string): APIEmbed[] => {
+  return [
+      {
+        type: EmbedType.Rich,
+        description: `Could not find anything on React documentation for **'${search}'**`,
+        color: EMBED_COLOR,
+        author: {
+          name: "React documentation",
+          icon_url:
+            "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1150px-React-icon.svg.png",
+          url: "https://react.dev/",
+        },
+      },
+    ];
 };
 
 export default commands;

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import fetch from "node-fetch";
-import { APIEmbed, ChannelType, EmbedType, Message, MessageCreateOptions, MessagePayload, TextChannel } from "discord.js";
+import { APIEmbed, ChannelType, EmbedType, Message, TextChannel } from "discord.js";
 import cooldown from "./cooldown";
 import { ChannelHandlers } from "../types";
 import { isStaff } from "../helpers/discord";

--- a/src/helpers/react-docs.ts
+++ b/src/helpers/react-docs.ts
@@ -30,17 +30,19 @@ export const getReactDocsContent = async (searchPath: string) => {
 };
 
 export const getReactDocsSearchKey = (search: string) => {
-  const searchKey = REACT_AVAILABLE_DOCS.find((key) => {
-    const matches = key.split("/");
-    const name = matches[matches.length - 1];
-    const namespace = matches.length <= 2 ? key : `${matches[0]}/${matches[2]}`;
+  const normalizedSearch = search.toLowerCase();
+
+  return REACT_AVAILABLE_DOCS.find((key) => {
+    const keyParts = key.split("/");
+    const name = keyParts[keyParts.length - 1];
+    const namespace =
+      keyParts.length <= 2 ? key : `${keyParts[0]}/${keyParts[2]}`;
 
     return (
-      namespace.toLowerCase().includes(search.toLowerCase()) ||
-      name.toLowerCase().includes(search.toLowerCase())
+      namespace.toLowerCase() === normalizedSearch ||
+      name.toLowerCase() === normalizedSearch
     );
   });
-  return searchKey;
 };
 
 const processReactDocumentation = (content: string) => {

--- a/src/helpers/react-docs.ts
+++ b/src/helpers/react-docs.ts
@@ -1,0 +1,119 @@
+import fetch from "node-fetch";
+import { gitHubToken } from "./env";
+
+const LOOKUP_REGEX = /<Intro>\s*(.*?)\s*<\/Intro>/gs;
+const LINK_REGEX = /\[([^\]]+)\]\((?!https?:\/\/)([^)]+)\)/g;
+
+const BASE_URL =
+  "https://api.github.com/repos/reactjs/react.dev/contents/src/content/reference/";
+
+export const getReactDocsContent = async (searchPath: string) => {
+  try {
+    const response = await fetch(`${BASE_URL}${searchPath}.md`, {
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${gitHubToken}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    const json = await response.json();
+    const contentBase64 = json.content;
+    const decodedContent = Buffer.from(contentBase64, "base64").toString(
+      "utf8",
+    );
+    return processReactDocumentation(decodedContent);
+  } catch (error) {
+    console.error("Error:", error);
+    return null;
+  }
+};
+
+export const getReactDocsSearchKey = (search: string) => {
+  const searchKey = REACT_AVAILABLE_DOCS.find((key) => {
+    const matches = key.split("/");
+    const name = matches[matches.length - 1];
+    const namespace = matches.length <= 2 ? key : `${matches[0]}/${matches[2]}`;
+
+    return (
+      namespace.toLowerCase().includes(search.toLowerCase()) ||
+      name.toLowerCase().includes(search.toLowerCase())
+    );
+  });
+  return searchKey;
+};
+
+const processReactDocumentation = (content: string) => {
+  const patchedContentLinks = content.replace(LINK_REGEX, (_, text, link) => {
+    return `[${text}](https://react.dev${link})`;
+  });
+
+  const matches = [...patchedContentLinks.matchAll(LOOKUP_REGEX)];
+
+  if (matches.length > 0) {
+    const [introContent] = matches.map(([, match]) => match.trim());
+    return introContent;
+  }
+
+  return null;
+};
+
+const REACT_AVAILABLE_DOCS = [
+  "react/cache",
+  "react/Children",
+  "react/cloneElement",
+  "react/Component",
+  "react/createContext",
+  "react/createElement",
+  "react/createFactory",
+  "react/createRef",
+  "react/experimental_taintObjectReference",
+  "react/experimental_taintUniqueValue",
+  "react/experimental_useEffectEvent",
+  "react/forwardRef",
+  "react/Fragment",
+  "react/isValidElement",
+  "react/lazy",
+  "react/legacy",
+  "react/memo",
+  "react/Profiler",
+  "react/PureComponent",
+  "react/startTransition",
+  "react/StrictMode",
+  "react/Suspense",
+  "react/use-client",
+  "react/use-server",
+  "react/use",
+  "react/useCallback",
+  "react/useContext",
+  "react/useDebugValue",
+  "react/useDeferredValue",
+  "react/useEffect",
+  "react/useId",
+  "react/useImperativeHandle",
+  "react/useInsertionEffect",
+  "react/useLayoutEffect",
+  "react/useMemo",
+  "react/useOptimistic",
+  "react/useReducer",
+  "react/useRef",
+  "react/useState",
+  "react/useSyncExternalStore",
+  "react/useTransition",
+  "react-dom/client/createRoot",
+  "react-dom/client/hydrateRoot",
+  "react-dom/hooks/useFormState",
+  "react-dom/hooks/useFormStatus",
+  "react-dom/server/renderToNodeStream",
+  "react-dom/server/renderToPipeableStream",
+  "react-dom/server/renderToReadableStream",
+  "react-dom/server/renderToStaticMarkup",
+  "react-dom/server/renderToStaticNodeStream",
+  "react-dom/server/renderToString",
+  "react-dom/unmountComponentAtNode",
+  "react-dom/hydrate",
+  "react-dom/render",
+  "react-dom/createPortal",
+  "react-dom/findDOMNode",
+  "react-dom/flushSync",
+];


### PR DESCRIPTION
Implemented additional commands `!docs` and `!react-docs` to search React documentation. The output embed will contain a link to documentation and short intro segment from their page.

Extra:
- Fixed MDN `icon_url` not being found.

![reactibot](https://github.com/reactiflux/reactibot/assets/45801982/a054008e-4549-4deb-a07b-96f9be34813f)
