### PR TITLE
Improvements to logs, fix crash in resume review, experience polish

### DIFF
--- a/src/features/emojiMod.ts
+++ b/src/features/emojiMod.ts
@@ -163,8 +163,8 @@ const emojiMod: ChannelHandlers = {
       reactor,
       message: fullMessage,
       reaction: fullReaction,
-      usersWhoReacted: usersWhoReacted.filter((x): x is GuildMember =>
-        Boolean(x),
+      usersWhoReacted: usersWhoReacted.filter(
+        (x): x is GuildMember => Boolean(x) && authorMember.id !== reactor.id,
       ),
     });
   },

--- a/src/features/log.ts
+++ b/src/features/log.ts
@@ -19,7 +19,7 @@ export const channelLog =
 
       if (channel?.type == ChannelType.GuildText) {
         channel.send({
-          content: `[${type}] ${text}`,
+          content: `[${type}] ${text}`.slice(0, 2000),
           allowedMentions: { users: [] },
         });
       }

--- a/src/features/resume.ts
+++ b/src/features/resume.ts
@@ -16,6 +16,7 @@ import {
   findResumeAttachment,
   REVIEW_COMMAND,
 } from "./resume-review";
+import { constructDiscordLink } from "../helpers/discord";
 
 const openai = new OpenAI({
   apiKey: openAiKey,
@@ -162,8 +163,11 @@ export const resumeResources = async (bot: Client) => {
         console.log({ content });
         const trimmed =
           content.at(0)?.slice(0, 2000) ?? "Oops! Something went wrong.";
-        logger.log("[RESUME]", `Feedback given:`);
-        logger.log("[RESUME]", trimmed);
+        logger.log(
+          "RESUME",
+          `Feedback given: ${constructDiscordLink(firstMessage)}`,
+        );
+        logger.log("RESUME", trimmed);
         deferred.edit({
           content: trimmed,
         });

--- a/src/features/resume.ts
+++ b/src/features/resume.ts
@@ -17,6 +17,7 @@ import {
   REVIEW_COMMAND,
 } from "./resume-review";
 import { constructDiscordLink } from "../helpers/discord";
+import { retry } from "./retry";
 
 const openai = new OpenAI({
   apiKey: openAiKey,
@@ -75,7 +76,8 @@ export const resumeResources = async (bot: Client) => {
       deferred.edit("Looking for a resume…");
       const messages = await interaction.channel.messages.fetch();
 
-      const firstMessage = await interaction.channel.fetchStarterMessage();
+      const { fetchStarterMessage } = interaction.channel;
+      const firstMessage = await retry(() => fetchStarterMessage(), 5, 10);
       if (!firstMessage) {
         await interaction.reply({
           ephemeral: true,

--- a/src/features/retry.ts
+++ b/src/features/retry.ts
@@ -1,0 +1,49 @@
+/**
+ * This is a chatGPT generated function, don't blame me. I did verify it works:
+```ts
+console.log(retryCount, {
+  backoff: delay * Math.pow(factor, retries - retryCount),
+  retryCount,
+});
+```
+as the first line of the `attempt` function produced: 
+```
+> 5 { backoff: 20, retryCount: 5 }
+> 4 { backoff: 40, retryCount: 4 }
+> 3 { backoff: 80, retryCount: 3 }
+> 2 { backoff: 160, retryCount: 2 }
+> 1 { backoff: 320, retryCount: 1 }
+> 0 { backoff: 640, retryCount: 0 }
+```
+
+ * Retries a promise-returning function with exponential backoff.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn - The function returning a promise to be retried.
+ * @param {number} [retries=3] - The number of retry attempts.
+ * @param {number} [delayMs=1000] - The initial delay in milliseconds before retrying.
+ * @returns {Promise<T>} A promise that resolves with the result of the function or rejects after all retries have been exhausted.
+ */
+export function retry<T>(
+  fn: () => Promise<T>,
+  retries = 3,
+  delayMs = 1000,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const attempt = (retryCount: number) => {
+      fn()
+        .then(resolve)
+        .catch((error) => {
+          if (retryCount <= 0) {
+            reject(error);
+          } else {
+            setTimeout(() => {
+              attempt(retryCount - 1);
+            }, delayMs * Math.pow(2, retries - retryCount));
+          }
+        });
+    };
+
+    attempt(retries);
+  });
+}

--- a/src/features/scheduled-messages.ts
+++ b/src/features/scheduled-messages.ts
@@ -94,17 +94,17 @@ How do I ask a good question <https://stackoverflow.com/help/how-to-ask>
     message: {
       content: `Check our the other channels too! This is our highest-traffic channel, which may mean your question gets missed as other discussions happen.
 
-#help-js For questions about pure Javscript problems.
-#help-styling For questions about CSS or other visual problems.
-#help-backend For questions about issues with your server code.
-#code-review Get deeper review of a snippet of code.
-#jobs-advice If you have a question about your job or career, ask it in here.
-#general-tech Discussion of non-JS code, or that new laptop you're deciding on.
-#tooling for questions about building, linting, generating, or otherwise processing your code.
+<#565213527673929729> For questions about pure Javscript problems.
+<#105765765117935616> For questions about CSS or other visual problems.
+<#145170347921113088> For questions about issues with your server code.
+<#105765859191975936> Get deeper review of a snippet of code.
+<#287623405946011648> If you have a question about your job or career, ask it in here.
+<#547620660482932737> Discussion of non-JS code, or that new laptop you're deciding on.
+<#108428584783220736> for questions about building, linting, generating, or otherwise processing your code.
 
-Looking for work? Trying to hire? Check out #job-board, or <https://reactiflux.com/jobs>
+Looking for work? Trying to hire? Check out <#103882387330457600>, or <https://reactiflux.com/jobs>
 
-Has someone been really helpful? Shoutout who and what in #thanks! We keep an eye in there as one way to find new MVPs. Give us all the reactions in there too!
+Has someone been really helpful? Shoutout who and what in <#798567961468076072>! We keep an eye in there as one way to find new MVPs. Give us all the reactions in there too!
 
 Please remember our Code of Conduct: <https://reactiflux.com/conduct>
 and our guidelines for promotion: <https://reactiflux.com/promotion>


### PR DESCRIPTION
Fixes #382 by adding a `retry()` helper and wrapping the `fetchStarterMessage` call.
Fixes #358 by extending the existing filter call to check IDs
Improves but leaves #380 open by linking to channels correctly
Fixes an issue where AI resume review sometimes wouldn't log because it was too long, by truncating output in the channel log helper
Improves our logging for resume feedback by linking to the source thread for the log