### PR TITLE
fix: reactibot do not send cooldown message without attachment

### DIFF
--- a/src/features/resume-review.ts
+++ b/src/features/resume-review.ts
@@ -53,9 +53,11 @@ const resumeReviewPdf: ChannelHandlers = {
     const cooldownKey = `resume-${message.channelId}`;
 
     if (cooldown.hasCooldown(message.author.id, cooldownKey)) {
-      message.channel.send(
-        "You posted just a few minutes ago. Please wait a bit before creating a new preview.",
-      );
+      if (findResumeAttachment(message)) {
+        message.channel.send(
+          "You posted just a few minutes ago. Please wait a bit before creating a new preview.",
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
Resolve issue where Reactibot would send cooldown message to occurring messages without attachments, when user has cooldown for pdf generation.