### PR TITLE
timeout-logs-tweaks

### DIFF
--- a/src/features/mod-activity.ts
+++ b/src/features/mod-activity.ts
@@ -13,12 +13,17 @@ const guildMemberTimeoutHandler = (
   const oldTimeout = oldMember.communicationDisabledUntil;
   const newTimeout = newMember.communicationDisabledUntil;
 
+  const date = new Date();
+
   if (!oldTimeout && newTimeout) {
-    logger.log(
-      "TIMEOUT",
-      `${newMember.user.tag} has been timed out in ${newMember.guild.name} until ${newTimeout}.`,
-      "modLog",
-    );
+    if (newTimeout >= date) {
+      // makes sure we don't log timeouts from the past if a user's role updates. It's still possible that a user is updated during a timeout, but this is the best we can do.
+      logger.log(
+        "TIMEOUT",
+        `${newMember.user.tag} has been timed out in ${newMember.guild.name} until ${newTimeout}.`,
+        "modLog",
+      );
+    }
   } else if (oldTimeout && !newTimeout) {
     logger.log(
       "TIMEOUT END",


### PR DESCRIPTION
make sure timeout events dont fire on historical timeouts