### PR TITLE
fix: this context lost on destruct

### DIFF
--- a/src/features/resume.ts
+++ b/src/features/resume.ts
@@ -76,8 +76,12 @@ export const resumeResources = async (bot: Client) => {
       deferred.edit("Looking for a resume…");
       const messages = await interaction.channel.messages.fetch();
 
-      const { fetchStarterMessage } = interaction.channel;
-      const firstMessage = await retry(() => fetchStarterMessage(), 5, 10);
+      const channel = interaction.channel;
+      const firstMessage = await retry(
+        () => channel.fetchStarterMessage(),
+        5,
+        10,
+      );
       if (!firstMessage) {
         await interaction.reply({
           ephemeral: true,


### PR DESCRIPTION
Fixes issue when `this` is `undefined` when we have destructed the `fetchStarterMessage`.

```js
[ERROR] Cannot read properties of undefined (reading 'parent') TypeError: Cannot read properties of undefined (reading 'parent')
    at fetchStarterMessage (/build/reactibot/node_modules/discord.js/src/structures/ThreadChannel.js:315:26)
```