### PR TITLE
fix: add error logging and retry to threadCreate resume

### DIFF
--- a/src/features/retry.ts
+++ b/src/features/retry.ts
@@ -20,15 +20,15 @@ as the first line of the `attempt` function produced:
  *
  * @template T
  * @param {() => Promise<T>} fn - The function returning a promise to be retried.
- * @param {number} [retries=3] - The number of retry attempts.
- * @param {number} [delayMs=1000] - The initial delay in milliseconds before retrying.
+ * @param {{ retries?: number; delayMs?: number }} [options] - The retry options.
  * @returns {Promise<T>} A promise that resolves with the result of the function or rejects after all retries have been exhausted.
  */
 export function retry<T>(
   fn: () => Promise<T>,
-  retries = 3,
-  delayMs = 1000,
+  options = { retries: 3, delayMs: 1000 },
 ): Promise<T> {
+  const { retries, delayMs } = options;
+
   return new Promise((resolve, reject) => {
     const attempt = (retryCount: number) => {
       fn()


### PR DESCRIPTION
Add additional error logging for the resume feature and handle retrying the firstMessage when thread has been created