### PR TITLE
Share top posts from /r/reactjs every night at midnight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "discord.js": "14.15.3",
         "dotenv": "16.4.5",
         "gists": "2.0.0",
+        "html-entities": "^2.5.2",
         "lru-cache": "10.2.2",
         "node-cron": "3.0.3",
         "node-fetch": "2.6.12",
@@ -3131,6 +3132,21 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "node_modules/html-entities": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ]
     },
     "node_modules/htmlparser2": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "discord.js": "14.15.3",
     "dotenv": "16.4.5",
     "gists": "2.0.0",
+    "html-entities": "^2.5.2",
     "lru-cache": "10.2.2",
     "node-cron": "3.0.3",
     "node-fetch": "2.6.12",

--- a/src/features/scheduled-messages.ts
+++ b/src/features/scheduled-messages.ts
@@ -4,6 +4,8 @@ import { CHANNELS } from "../constants/channels";
 import { logger } from "./log";
 import { FREQUENCY, scheduleTask, SPECIFIED_TIMES } from "../helpers/schedule";
 import { ChannelType } from "discord.js";
+import { decode } from "html-entities";
+import { countLines } from "../helpers/string";
 
 type MessageConfig = {
   postTo: {
@@ -119,6 +121,59 @@ If you see anything that violates our rules, help alert the mods by reacting to 
       content: `Have you read our Code of Conduct? <https://reactiflux.com/conduct>
 
 Let us know if anything crosses a line: give it a 👎, or if you'd prefer to remain anonymous, let mods know from the message context menu (right click > Apps > report message) or with the form at <https://reactiflux.com/contact>`,
+    },
+  },
+  {
+    postTo: [
+      {
+        interval: SPECIFIED_TIMES.midnight,
+        channelId: CHANNELS.techReadsAndNews,
+      },
+    ],
+    message: async (channel) => {
+      const res = await fetch(
+        "https://old.reddit.com/r/reactjs/top.json?sort=top&t=day&limit=10",
+      );
+      const feed = await res.json();
+
+      const top = (feed.data.children as any[])
+        .filter(
+          ({ data: post }: any) =>
+            post.ups - post.downs >= 10 &&
+            countLines(post.selftext) <= 15 &&
+            post.selftext.length < 2000 &&
+            post.upvote_ratio > 0.65,
+        )
+        .slice(0, 3)
+        .map(({ data: post }) => ({
+          url: `https://old.reddit.com${post.permalink}`,
+          title: post.title,
+          author: post.author,
+          body: decode(post.selftext).trim().slice(0, 2000),
+          subreddit: post.subreddit_name_prefixed,
+          votes: {
+            score: post.ups,
+            up: Math.round(post.upvote_ratio * post.ups),
+            down: Math.round((1 - post.upvote_ratio) * post.ups),
+          },
+        }));
+
+      top.forEach((post) => {
+        channel.send({
+          embeds: [
+            {
+              description: `${post.votes.up - post.votes.down} 🔼 in ${post.subreddit} 
+-# (${post.votes.up} | ${post.votes.down}) 
+### [${post.title}](${post.url}) 
+by [/u/${post.author}](https://old.reddit.com/u/${post.author})
+
+${post.body}
+
+-# This is a once-daily summary of top posts from reddit`,
+            },
+          ],
+        });
+      });
     },
   },
 ];


### PR DESCRIPTION
<img width="497" alt="Screenshot 2024-08-08 at 9 56 21 PM" src="https://github.com/user-attachments/assets/f6372937-3233-451c-9bf3-d717cdc9012a">

Only shows a maximum of 5 posts, and only posts that meet this filter:

```js
post.ups - post.downs >= 10 &&
countLines(post.selftext) <= 15 &&
post.selftext.length < 2000 &&
post.upvote_ratio > 0.65,
```

So, > 10 points, < 15 lines of text, under 2k characters, and 65% upvoted. This should keep it from overwhelming the channel, but I've caught some solid resources coming through in Reddit so I thought this would be good. Resolves #389 