### PR TITLE
feature: added command !auth solves #398

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -1152,7 +1152,9 @@ _ _
         title: "",
         type: EmbedType.Rich,
         description: `
-Authentication is a critical part of most web applications. Below are some resources to help you get started with authentication:
+Authentication is a critical part of most web applications. Here are some resources to help you get started.
+- [JSON Web Tokens (JWT) are Dangerous for User Sessions](https://redis.io/blog/json-web-tokens-jwt-are-dangerous-for-user-sessions/)
+- [JWT should not be your default for sessions](https://evertpot.com/jwt-is-a-bad-default/)
         `,
         fields: [
           {

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -1141,6 +1141,60 @@ _ _
       });
     },
   },
+  {
+    words: ["!auth", "!authentication"],
+    help: "Provides a list of popular backend- and meta-frameworks",
+    category: "Web",
+    handleMessage: (msg) => {
+      const firstMention = msg.mentions.users.first();
+
+      const embed = {
+        title: "",
+        type: EmbedType.Rich,
+        description: `
+Authentication is a critical part of most web applications. Below are some resources to help you get started with authentication:
+        `,
+        fields: [
+          {
+            name: "Authentication Resources",
+            value: `
+- [TheCopenhagenBook](https://thecopenhagenbook.com/)
+- [OWASP Auth Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+- [OWASP Session Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)
+`,
+            inline: true,
+          },
+          {
+            name: "Authentication Libraries",
+            value: `
+- [Lucia](https://lucia-auth.com/)
+- [Auth.js](https://authjs.dev/)
+- [Passport](http://www.passportjs.org/)
+`,
+            inline: true,
+          },
+          {
+            name: "Auth as a service",
+            value: `
+- [Supabase](https://supabase.io/)
+- [Clerk](https://clerk.com/)
+- [Auth0](https://auth0.com/)
+`,
+            inline: true,
+          },
+        ],
+        color: EMBED_COLOR,
+      };
+
+      if (firstMention) {
+        embed.description = `Hey ${firstMention}, ${embed.description}`;
+      }
+
+      msg.channel.send({
+        embeds: [embed],
+      });
+    },
+  },
 ];
 
 const createCommandsMessage = () => {


### PR DESCRIPTION
Added command `!auth` to show authentication resources, additionally you can add a user to the reply as such and the user will be apart of the embed:
![image](https://github.com/user-attachments/assets/5b1f6296-a52f-4214-b5a2-89ddfc68fad6)

**Example reply from bot**
![image](https://github.com/user-attachments/assets/50067fc5-c961-4bb3-a683-37dc752b41f5)
