### PR TITLE
Compress 3 spaces down to 2

### DIFF
--- a/src/helpers/string.ts
+++ b/src/helpers/string.ts
@@ -25,3 +25,12 @@ export const compressLineBreaks = (s: string) => {
   }
   return s;
 };
+
+const TOO_MANY_SPACES = / {3}/g;
+const APPROPRIATE_SPACES = "  ";
+export const compressSpaces = (s: string) => {
+  while (TOO_MANY_SPACES.test(s)) {
+    s = s.replaceAll(TOO_MANY_SPACES, APPROPRIATE_SPACES);
+  }
+  return s;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,11 @@ import {
   StoredMessage,
   getJobPosts,
 } from "./features/jobs-moderation/job-mod-helpers.js";
-import { compressLineBreaks, simplifyString } from "./helpers/string.js";
+import {
+  compressSpaces,
+  compressLineBreaks,
+  simplifyString,
+} from "./helpers/string.js";
 import { constructDiscordLink } from "./helpers/discord.js";
 import { reactibotApiKey } from "./helpers/env.js";
 
@@ -275,7 +279,9 @@ const renderPost = (post: StoredMessage): RenderedPost => {
     tags: post.tags,
     type: post.type,
     createdAt: post.createdAt,
-    description: renderMdToHtml(compressLineBreaks(post.description)),
+    description: renderMdToHtml(
+      compressLineBreaks(compressSpaces(post.description)),
+    ),
     messageLink: constructDiscordLink(post.message),
     reactions: post.message.reactions.cache.map((r) => [
       r.emoji.name ?? "☐",


### PR DESCRIPTION
I spotted a weirdo formatted post that used spaces to emulate bullet points, which is bananas, but it also broke the  markdown formatter. Discord doesn't support the 4-spaces-for-code markdown format, so this is fine.