### PR TITLE
fix: Shared references causing auto thread to be added to new channels

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,6 @@ const addHandler = (
       channelHandlersById[channelId] = [...handlers];
     }
   });
-  console.log(channelHandlersById);
 };
 
 const handleMessage = async (message: Message) => {


### PR DESCRIPTION
**description**: This pull-request fixes #461 . The issue had to do with the addHandler function using mutated arrays or references rather than creating a new one resulting in an unexpected behaviour of the auto thread handler being added to new channels. In other words, *adding a handler to one channel might affect other channels that share the same reference.*


## steps to reproduce

1. Create a new channel in React Test Server and add it to channels constant ( using the testing-bug-thread channel)
```

const LOCAL_CHANNELS: Record<keyof typeof PRODUCTION_CHANNELS, string> = {
   newChannel: "1383553919950520450"
  helpReact: "926931785219207301",
helpJs:"950790460857794620"
 ...
};

const PRODUCTION_CHANNELS = {
  newChannel: "1383553919950520450"
  helpReact: "103696749012467712",
 helpJs:"950790460857794620"
  ...
};

```

2. Create a new empty handler
```
import type { ChannelHandlers } from "../types/index.d.ts";
import { EmbedType } from "discord.js";
import { EMBED_COLOR } from "./commands.js";

export const messageScanner: ChannelHandlers = {
  handleMessage: async ({ msg }) => {
    if (msg.author.bot) return;

    const warningMsg = `Testing message`;
    await msg.reply({
      embeds: [
        {
          title: "Oops! Wrong Channel, Maybe?",
          type: EmbedType.Rich,
          description: warningMsg,
          color: EMBED_COLOR,
        },
      ],
    });


  },
};



``` 

3.  Add the new handler with the  new channel ID and a shared channel auto thread ID like helpJs: 
```
addHandler([CHANNELS.newChannel,CHANNELS.helpJs>], newHandler);

```
4. Type in the testing-bug-thread channel , and a thread will be created:
<img width="455" alt="thread-created" src="https://github.com/user-attachments/assets/37ad4ef4-9652-4d66-861c-72ae3e174b25" />

## Actual Behaviour
New channels added will result in having shared handlers. 

## The expected behaviour
Any new channels added should not have other handlers added to them unless specified.

## Solution

The solution now replaces .push and declaration with the spread operator.
```
// original
if (existingHandlers) {
      existingHandlers.push(...handlers);
    } else {
      channelHandlersById[channelId] = handlers;
    }
```

```
// solution
 if (existingHandlers) {
      // Create a new array to avoid mutating the existing one
      channelHandlersById[channelId] = [...existingHandlers, ...handlers];
    } else {
      channelHandlersById[channelId] = [...handlers];
    }
```



