### PR TITLE
update: added option in regex for insecure urls

### DIFF
--- a/src/features/jobs-moderation/validate.ts
+++ b/src/features/jobs-moderation/validate.ts
@@ -98,7 +98,7 @@ export const participation: JobPostValidator = (posts, message) => {
   return [];
 };
 
-const urlRegex = /(https):\/\/[^\s/$.?#].[^\s]*/g;
+const urlRegex = /(https?):\/\/[^\s/$.?#].[^\s]*/g;
 export const links: JobPostValidator<false> = (posts) => {
   const errors: PostFailures[] = [];
   posts.forEach(({ tags, description }) => {


### PR DESCRIPTION
This pull-request resolves #456 by adding a special "?" to accept insecure or secure URLs.