### PR TITLE
fix: undefined properties and removed colon in print statement

### DIFF
--- a/src/features/looking-for-group.ts
+++ b/src/features/looking-for-group.ts
@@ -50,7 +50,18 @@ export const lookingForGroup = async (bot: Client) => {
     }
 
     try {
-      await retry(thread.fetchStarterMessage);
+      const messages = await retry(() => thread.messages.fetch({ limit: 1 }));
+      const message = messages.first();
+      if (!message) {
+        return;
+      }
+
+      if (
+        !(message.attachments && message.attachments.size > 0) &&
+        message.content.length === 0
+      ) {
+        return;
+      }
       await thread.send({
         embeds: [
           {
@@ -78,7 +89,7 @@ Post authors: Once you've found collaborators or a project to contribute to, ple
       });
     } catch (e) {
       if (e instanceof Error) {
-        logger.log("looking for group threadCreate: ", e);
+        logger.log("looking for group threadCreate", e);
       }
     }
   });


### PR DESCRIPTION
### Summary
Switched from fetchStarterMessage to just fetching the first message in the thread and checking for any attachments or content before sending a bot response. In addition, added a retry in case of race conditions. Also removed colon from print statement for better readability.

### Issue
The error Cannot read properties of undefined (reading 'parent') originated from fetchStarterMessage when a forum post only contains an image and no description. 

### Solution
However, after care analysis, the fetchStarterMessage seems to only apply for non-forum channels as forums are different and do not have a parent id post, unlike normal threads when tested in development. For this reason, the fetchStarterMessage was removed for now.