### PR TITLE
chore: added code block check for 1-3 backticks

### DIFF
--- a/src/features/job-scanner.ts
+++ b/src/features/job-scanner.ts
@@ -42,7 +42,7 @@ const jobKeywords = [
 
 const currencyKeywords = ["₹", "€", "$"];
 const hasCodeBlockWithDollarSign = (content: string): boolean => {
-  const codeBlockRegex = /```[\s\S]*?\$[\s\S]*?```/g;
+  const codeBlockRegex = /(`{1,3})([\s\S]*?\$[\s\S]*?)\1/g;
   return codeBlockRegex.test(content);
 };
 


### PR DESCRIPTION
**description**:  Currently, the job scanner gives false positives for code blocks with 1-2 dollar signs. This change, by allowing 1-3 will prevent messages with dollar signs inside code blocks from being marked as job postings.