### PR TITLE
fix: added ignore list for autothread channels on xCancel Generation

### DIFF
--- a/src/features/x-cancel-generator.ts
+++ b/src/features/x-cancel-generator.ts
@@ -1,18 +1,29 @@
+import { CHANNELS } from "../constants/channels.js";
 import type { ChannelHandlers } from "../types/index.js";
 
 export const TWITTER_REGEX =
   /https?:\/\/(?:www\.)?(?:x|twitter)\.com\/\w+\/status\/\d+/i;
 
+const THREAD_CHANNELS = [
+  CHANNELS.events,
+  CHANNELS.iBuiltThis,
+  CHANNELS.iWroteThis,
+  CHANNELS.techReadsAndNews,
+  CHANNELS.twitterFeed,
+];
 const xCancelGenerator: ChannelHandlers = {
   handleMessage: async ({ msg }) => {
     const match = TWITTER_REGEX.exec(msg.content);
     if (!match || msg.author.bot) return; // Ignore bots to prevent loops
-    msg.suppressEmbeds(true);
-    const [url] = match;
-    const alternativeUrl = url.replace(/(x|twitter)\.com/i, "xcancel.com");
-    await msg.channel.send(
-      `[Converted to \`xcancel.com\` for members with no \`x\` account](${alternativeUrl})`,
-    );
+    const isThreadChannel = THREAD_CHANNELS.includes(msg.channel.id);
+    if (!isThreadChannel) {
+      msg.suppressEmbeds(true);
+      const [url] = match;
+      const alternativeUrl = url.replace(/(x|twitter)\.com/i, "xcancel.com");
+      await msg.channel.send(
+        `[Converted to \`xcancel.com\` for members with no \`x\` account](${alternativeUrl})`,
+      );
+    }
   },
 };
 


### PR DESCRIPTION
## Summary
Resolved a race condition between `promotionThread` and `xCancelGenerator` that caused duplicate or misaligned bot responses in specific channels.

## Problem
When a user posts a link in a channel managed by both handlers, a race condition occurs. The xCancelGenerator would trigger on the main message simultaneously with the thread creation, leading to fragmented bot responses and formatting issues within the newly created threads.
<img width="776" height="733" alt="image" src="https://github.com/user-attachments/assets/b16e418e-e17a-40fe-a409-b853251d5d39" />

## Solution
Implemented a check to ensure `xCancelGenerator` logic is skipped in channels where `promotionThread` is active. This ensures the two features are mutually exclusive at the channel level, while still allowing the converter to run in standard text channels.

```ts
const THREAD_CHANNELS = [
  CHANNELS.events,
  CHANNELS.iBuiltThis,
  CHANNELS.iWroteThis,
  CHANNELS.techReadsAndNews,
  CHANNELS.twitterFeed,
];

// ... inside handleMessage
const isThreadChannel = THREAD_CHANNELS.includes(msg.channel.id);
if (!isThreadChannel) {
   // Execute xCancel logic
}
```

## Potential Future Optimisations.
Centralized Config: Export the handler-to-channel mappings from index.ts as a shared constant. This would provide a single source of truth for channel-specific logic and prevent hardcoding ID lists across multiple generators.