### PR TITLE
fix(replies): update xcancel embed suppression

### DIFF
--- a/src/features/x-cancel-generator.ts
+++ b/src/features/x-cancel-generator.ts
@@ -17,11 +17,13 @@ const xCancelGenerator: ChannelHandlers = {
     if (!match || msg.author.bot) return; // Ignore bots to prevent loops
     const isThreadChannel = THREAD_CHANNELS.includes(msg.channel.id);
     if (!isThreadChannel) {
-      msg.suppressEmbeds(true);
+      // The below line will suppress the original message embed (if ever required again in future)
+      // msg.suppressEmbeds(true);
       const [url] = match;
       const alternativeUrl = url.replace(/(x|twitter)\.com/i, "xcancel.com");
+      // Including the < brackets > around alternativeLink is recognized markdown to suppress an embed
       await msg.channel.send(
-        `[Converted to \`xcancel.com\` for members with no \`x\` account](${alternativeUrl})`,
+        `[Converted to \`xcancel.com\` for members with no \`x\` account](<${alternativeUrl}>)`,
       );
     }
   },


### PR DESCRIPTION
Currently, when a raw x.com or twitter.com link is posted, the bot generates an xcancel.com alternative. However, xcancel embeds have become increasingly unreliable, often failing to render content.

As a stop-gap measure, this PR modifies the handler to:

Preserve the native X embed: We will no longer attempt to suppress the original message's embed, allowing users to view content "at a glance" via the official preview.

Suppress the xcancel embed: The fallback link will now be wrapped in angle brackets (<URL>). This provides a clickable alternative for members without X accounts without creating a broken or redundant second embed.

feature code is commented to help future contributors revert or make changes accordingly. 