### PR TITLE
chore: remove xCancel embed

### DIFF
--- a/src/features/x-cancel-generator.ts
+++ b/src/features/x-cancel-generator.ts
@@ -1,32 +1,11 @@
-import { CHANNELS } from "../constants/channels.js";
-import type { ChannelHandlers } from "../types/index.js";
+/*
+This feature served the community well and provided an alternative route to view and participate in discourse without barriers. 
 
-export const TWITTER_REGEX =
-  /https?:\/\/(?:www\.)?(?:x|twitter)\.com\/\w+\/status\/\d+/i;
+- Thank you xCancel.
 
-const THREAD_CHANNELS = [
-  CHANNELS.events,
-  CHANNELS.iBuiltThis,
-  CHANNELS.iWroteThis,
-  CHANNELS.techReadsAndNews,
-  CHANNELS.twitterFeed,
-];
-const xCancelGenerator: ChannelHandlers = {
-  handleMessage: async ({ msg }) => {
-    const match = TWITTER_REGEX.exec(msg.content);
-    if (!match || msg.author.bot) return; // Ignore bots to prevent loops
-    const isThreadChannel = THREAD_CHANNELS.includes(msg.channel.id);
-    if (!isThreadChannel) {
-      // The below line will suppress the original message embed (if ever required again in future)
-      // msg.suppressEmbeds(true);
-      const [url] = match;
-      const alternativeUrl = url.replace(/(x|twitter)\.com/i, "xcancel.com");
-      // Including the < brackets > around alternativeLink is recognized markdown to suppress an embed
-      await msg.channel.send(
-        `[Converted to \`xcancel.com\` for members with no \`x\` account](<${alternativeUrl}>)`,
-      );
-    }
-  },
-};
-
-export default xCancelGenerator;
+    A note from xCancel below:
+    On Monday 24th August at 8PM EST, we received at letter from X Corp. asking to cease and desist the service XCancel.
+    The service XCancel is stopped until further notice.
+    We are seeking legal advice and won't share more details for now.
+    Thank you for the trust you have put in these two years of XCancel.
+*/

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,6 @@ import voiceActivity from "./features/voice-activity.js";
 import type { ChannelHandlers } from "./types/index.js";
 import { scheduleMessages } from "./features/scheduled-messages.js";
 import tsPlaygroundLinkShortener from "./features/tsplay.js";
-import xCancelGenerator from "./features/x-cancel-generator.js";
 import { CHANNELS, initCachedChannels } from "./constants/channels.js";
 import { scheduleTask } from "./helpers/schedule.js";
 import { discordToken, isProd } from "./helpers/env.js";
@@ -203,7 +202,6 @@ addHandler("*", [
   autoban,
   emojiMod,
   tsPlaygroundLinkShortener,
-  xCancelGenerator,
   troll,
 ]);
 


### PR DESCRIPTION
Removed the xCancel functionality as it is currently not functional.

This feature served the community well and provided an alternative route to view and participate in discourse without barriers.

~ Thank you xCancel.

A note from xCancel below:

> On Monday 24th August at 8PM EST, we received at letter from X Corp. asking to cease and desist the service XCancel.
The service XCancel is stopped until further notice. We are seeking legal advice and won't share more details for now. Thank you for the trust you have put in these two years of XCancel.